### PR TITLE
Initial folder layout to allow further commits

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,92 @@
+##### Source code #####
+
+## C++ and C source files
+*.c                     text diff=cpp
+*.h                     text diff=cpp
+*.cpp                   text diff=cpp
+*.cxx                   text diff=cpp
+*.hpp                   text diff=cpp
+
+## Python scripts
+*.py                    text eol=lf diff=python
+
+## Perl scripts/libraries/modules
+*.perl                  text eol=lf diff=perl
+*.pl                    text eol=lf diff=perl
+*.pm                    text eol=lf diff=perl
+
+## Shell scripts
+*.sh                    text eol=lf
+*.bash                  text eol=lf
+
+## Windows batch and PowerShell scripts
+*.bat                   text eol=crlf
+*.cmd                   text eol=crlf
+*.ps1                   text eol=crlf
+
+##### Other file types #####
+
+## Text files and documentation
+*.txt                   text
+README*                 text
+INSTALL*                text
+LICENSE*                text
+
+## Non-text documentation
+*.html                  text diff=html
+*.pdf                   binary
+*.rtf                   binary
+
+## Doxygen documentation configuration files
+Doxyfile                text
+*.dox                   text
+
+## Image files
+*.png                   binary
+*.PNG                   binary
+*.jpg                   binary
+*.JPG                   binary
+*.gif                   binary
+*.GIF                   binary
+*.bmp                   binary
+*.BMP                   binary
+*.ico                   binary
+*.ICO                   binary
+*.ppm                   binary
+*.pgm                   binary
+*.pbm                   binary
+*.xpm                   -text diff -merge
+
+## Vector graphics
+*.svg                   -text diff -merge
+
+## CMake files
+CMakeLists.txt          text eol=lf
+
+## Makefiles
+Makefile                text
+makefile                text
+GNUmakefile             text
+*.mk                    text
+
+## Various IDE project files, etc
+*.sln                   -text diff merge
+*.vcxproj               -text diff -merge
+*.vcxproj.filters       -text diff -merge
+*.props                 -text diff -merge
+*.pbxproj               -text diff -merge
+
+## Resource files and UI design descriptions
+*.rc                    text eol=crlf
+
+## Diff/patch files
+*.diff                  text diff -merge
+*.patch                 text diff -merge
+
+## XML and configuration
+*.xml                   text
+*.cfg                   text
+
+## Self-reference =)
+.gitignore              text
+.gitattributes          text

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 *.c                     text diff=cpp
 *.h                     text diff=cpp
 *.cpp                   text diff=cpp
+*.cc                    text diff=cpp
 *.cxx                   text diff=cpp
 *.hpp                   text diff=cpp
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,19 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe your environment** Describe any aspect of your environment relevant to the problem, including your platform, build system, version numbers of installed dependencies, etc. If you're reporting a problem with a specific version of a library in this repo, please check whether the problem has been fixed on master.
+
+**Steps to reproduce**
+Describe exactly how to reproduce the error. Include a code sample if applicable.
+
+**What is the expected behavior?**
+What did you expect to see?
+
+**What is the actual behavior?**
+What did you see instead?
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Create a report to help us improve
 labels: bug
 ---
 
-**Describe your environment** Describe any aspect of your environment relevant to the problem, including your platform, build system, version numbers of installed dependencies, etc. If you're reporting a problem with a specific version of a library in this repo, please check whether the problem has been fixed on master.
+**Describe your environment** Describe any aspect of your environment relevant to the problem, including your platform, build system, version numbers of installed dependencies, etc. If you're reporting a problem with a specific version of a library in this repo, please check whether the problem has been fixed on main branch.
 
 **Steps to reproduce**
 Describe exactly how to reproduce the error. Include a code sample if applicable.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+labels: feature-request
+---
+
+Before opening a feature request against this repo, consider whether the feature should/could be implemented in the [other OpenTelemetry client libraries](https://github.com/open-telemetry/). If so, please [open an issue on opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification/issues/new) first.
+
+**Is your feature request related to a problem?**
+If so, provide a concise description of the problem.
+
+**Describe the solution you'd like**
+What do you want to happen instead? What is the expected behavior?
+
+**Describe alternatives you've considered**
+Which alternative solutions or features have you considered?
+
+**Additional context**
+Add any other context about the feature request here.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# Ref. https://github.com/github/gitignore/blob/master/C%2B%2B.gitignore
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Bazel files
+/bazel-*
+
+# Mac
+.DS_Store
+
+# Output directories
+/out
+/out.*
+# Indicator that the tools were deployed
+.buildtools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,6 @@ See the [public meeting notes](https://docs.google.com/document/d/1i1E4-_y4uJ083
 for a summary description of past meetings. To request edit access, join the
 meeting or get in touch on [Gitter](https://gitter.im/open-telemetry/opentelemetry-cpp).
 
-See the [community membership document](https://github.com/open-telemetry/community/blob/master/community-membership.md)
-on how to become a [**Member**](https://github.com/open-telemetry/community/blob/master/community-membership.md#member),
-[**Approver**](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)
-and [**Maintainer**](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer).
-
 ## Development
 
 TBD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to opentelemetry-cpp-contrib
+
+The OpenTelemetry C/C++ special interest group (SIG) meets regularly. See the
+OpenTelemetry [community](https://github.com/open-telemetry/community#cc-sdk)
+repo for information on this and other language SIGs.
+
+See the [public meeting notes](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit)
+for a summary description of past meetings. To request edit access, join the
+meeting or get in touch on [Gitter](https://gitter.im/open-telemetry/opentelemetry-cpp).
+
+See the [community membership document](https://github.com/open-telemetry/community/blob/master/community-membership.md)
+on how to become a [**Member**](https://github.com/open-telemetry/community/blob/master/community-membership.md#member),
+[**Approver**](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)
+and [**Maintainer**](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer).
+
+## Development
+
+TBD
+
+### Build and Run Code Examples
+
+TBD
+
+## Pull Requests
+
+### How to Send Pull Requests
+
+Everyone is welcome to contribute code to `opentelemetry-cpp-contrib` via GitHub pull
+requests (PRs).
+
+To create a new PR, fork the project in GitHub and clone the upstream repo:
+
+```sh
+git clone --recursive https://github.com/open-telemetry/opentelemetry-cpp-contrib.git
+```
+
+Add your fork as a remote:
+
+```sh
+git remote add fork https://github.com/YOUR_GITHUB_USERNAME/opentelemetry-cpp-contrib.git
+```
+
+Check out a new branch, make modifications and push the branch to your fork:
+
+```sh
+git checkout -b feature
+# edit files
+git commit
+git push fork feature
+```
+
+Open a pull request against the main `opentelemetry-cpp-contrib` repo.
+
+### How to Receive Comments
+
+* If the PR is not ready for review, please put `[WIP]` in the title, tag it
+  as `work-in-progress`, or mark it as [`draft`](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
+* Make sure [CLA](https://identity.linuxfoundation.org/projects/cncf) is
+  signed and CI is clear.
+
+### How to Get PRs Merged
+
+This section needs to be written.
+
+## Useful Resources
+
+Please refer to main OpenTelemetry C++ SDK [contributing guidelines](https://github.com/open-telemetry/opentelemetry-cpp/blob/master/CONTRIBUTING.md) for more details.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ guidelines](./CONTRIBUTING.md)
 
 ## Support
 
-This repository is maintained by [.NET SDK
-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-maintainers)
-team and [.NET SDK
-approvers](https://github.com/orgs/open-telemetry/teams/dotnet-approvers) can
+This repository is maintained by [C++ SDK
+maintainers](https://github.com/orgs/open-telemetry/teams/cpp-maintainers)
+team and [C++ SDK
+approvers](https://github.com/orgs/open-telemetry/teams/cpp-approvers) can
 help with reviews and code approval. However, as individual components are
 developed by numerous contributors, approvers and maintainers are not expected
 to directly contribute to every component.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# opentelemetry-cpp-contrib
+# OpenTelemetry C++ Contrib
+
+This repository contains set of components extending functionality of the
+OpenTelemetry SDK. Instrumentation libraries, exporters, and other components
+can find their home here.
+
+## Contributing
+
+For information on how to contribute, consult [the contributing
+guidelines](./CONTRIBUTING.md)
+
+## Support
+
+This repository is maintained by [.NET SDK
+maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-maintainers)
+team and [.NET SDK
+approvers](https://github.com/orgs/open-telemetry/teams/dotnet-approvers) can
+help with reviews and code approval. However, as individual components are
+developed by numerous contributors, approvers and maintainers are not expected
+to directly contribute to every component.
+
+This repository is great for community supported components. Vendor specific
+code that requires a higher supportability guarantees needs to be placed in
+vendor's repository. Packages in vendor repositories would be prefixed with the
+vendor name to signify the difference from community-supported components.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,16 @@ guidelines](./CONTRIBUTING.md)
 
 ## Support
 
-This repository is maintained by [C++ SDK
-maintainers](https://github.com/orgs/open-telemetry/teams/cpp-maintainers)
-team and [C++ SDK
-approvers](https://github.com/orgs/open-telemetry/teams/cpp-approvers) can
-help with reviews and code approval. However, as individual components are
-developed by numerous contributors, approvers and maintainers are not expected
-to directly contribute to every component.
+This repository accepts public contributions. Individual components are
+developed by numerous contributors. Approvers and maintainers of the main
+OpenTelemetry C++ SDK repository are not expected to directly contribute
+to every component.
+
+GitHub `CODEOWNER`S file is a simple way to automate away some of the pain
+associated with the review system on github, by automatically assigning
+reviewers to a pull request based on which files were modified. Individual
+components are encouraged to propose changes to `CODEOWNER`S file following
+the process [described here](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners).
 
 This repository is great for community supported components. Vendor specific
 code that requires a higher supportability guarantees needs to be placed in

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+This directory contains OpenTelemetry C++ contrib documentation.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Examples
+
+This directory contains OpenTelemetry C++ contrib examples.

--- a/exporters/README.md
+++ b/exporters/README.md
@@ -1,0 +1,3 @@
+# Exporters
+
+This directory contains OpenTelemetry C++ community-supported exporters.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,4 @@
+# Tools
+
+This directory contains OpenTelemetry C++ contrib tools.
+


### PR DESCRIPTION
Initial folder layout to allow further commits. I intentionally left a few changes as `TBD` to allow for additional flexibility:
- coding style
- code ownership
- formatting rules

Different contributing individuals and companies should be able to use their own applicable coding style, i.e. if a module enables integration with a different system or product, it would most likely follow the coding style rules of the product.

I am not sure 100% re. the license, but keeping it Apache License Version 2.0 as the main repo. We may need to add an additional provision that _optional_ community-contributed projects may each be under their own license?