### PR TITLE
nginx: add support for scriptable attributes

### DIFF
--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -38,7 +38,14 @@ jobs:
       - name: setup
         run: |
           sudo ./instrumentation/nginx/ci/setup_ci_environment.sh
+      - name: cache grpc checkout
+        id: cache-grpc-src
+        uses: actions/cache@v2
+        with:
+          path: "instrumentation/nginx/grpc"
+          key: ${{ runner.os }}-grpc-src
       - name: checkout grpc
+        if: steps.cache-grpc-src.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with: 
           repository: "grpc/grpc"
@@ -46,7 +53,14 @@ jobs:
           fetch-depth: 1
           path: "instrumentation/nginx/grpc"
           submodules: "recursive"
+      - name: cache grpc build
+        id: cache-grpc-build
+        uses: actions/cache@v2
+        with:
+          path: "install/grpc"
+          key: ${{ runner.os}}-grpc-build
       - name: build grpc
+        if: steps.cache-grpc-build.outputs.cache-hit != 'true'
         run: |
           cd instrumentation/nginx
           ./ci/grpc.sh

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -38,14 +38,7 @@ jobs:
       - name: setup
         run: |
           sudo ./instrumentation/nginx/ci/setup_ci_environment.sh
-      - name: cache grpc checkout
-        id: cache-grpc-src
-        uses: actions/cache@v2
-        with:
-          path: "instrumentation/nginx/grpc"
-          key: ${{ runner.os }}-grpc-src
       - name: checkout grpc
-        if: steps.cache-grpc-src.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with: 
           repository: "grpc/grpc"
@@ -53,14 +46,7 @@ jobs:
           fetch-depth: 1
           path: "instrumentation/nginx/grpc"
           submodules: "recursive"
-      - name: cache grpc build
-        id: cache-grpc-build
-        uses: actions/cache@v2
-        with:
-          path: "install/grpc"
-          key: ${{ runner.os}}-grpc-build
       - name: build grpc
-        if: steps.cache-grpc-build.outputs.cache-hit != 'true'
         run: |
           cd instrumentation/nginx
           ./ci/grpc.sh

--- a/instrumentation/nginx/README.md
+++ b/instrumentation/nginx/README.md
@@ -9,8 +9,11 @@ Supported propagation types:
 ## Requirements
 
 * OS: Linux
-* Nginx: latest stable - [1.18.0](http://nginx.org/en/download.html)
-* Nginx modules: ngx_http_upstream_module (proxy_pass), ngx_http_fastcgi_module (fastcgi_pass)
+* Nginx
+  * latest stable - [1.18.0](http://nginx.org/en/download.html)
+* Nginx modules
+  * ngx_http_upstream_module (proxy_pass)
+  * ngx_http_fastcgi_module (fastcgi_pass)
 
 Additional platforms and/or versions coming soon.
 

--- a/instrumentation/nginx/README.md
+++ b/instrumentation/nginx/README.md
@@ -39,6 +39,8 @@ http {
     location = /b3 {
       opentelemetry_operation_name my_other_backend;
       opentelemetry_propagate b3;
+      # Adds a custom attribute to the span
+      opentelemetry_attribute "req.time" "$msec";
       proxy_pass http://localhost:3501/;
     }
 
@@ -80,6 +82,15 @@ Enable or disable OpenTelemetry (default: enabled).
 
 - **required**: `false`
 - **syntax**: `opentelemetry on|off`
+- **block**: `http`, `server`, `location`
+
+### `opentelemetry_attribute`
+
+Adds a custom attribute to the span. It is possible to access nginx variables, e.g.
+`opentelemetry_attribute "my.user.agent" "$http_user_agent"`.
+
+- **required**: `false`
+- **syntax**: `opentelemetry_attribute <key> <value>`
 - **block**: `http`, `server`, `location`
 
 ### `opentelemetry_config`
@@ -146,9 +157,8 @@ Dependencies:
 * [Docker Compose](https://docs.docker.com/compose/install/)
 
 ```
-cd test
-docker build -t otel-nginx-test/nginx -f Dockerfile .
-docker build -t otel-nginx-test/express-backend -f backend/simple_express/Dockerfile backend/simple_express
-cd instrumentation
+docker build -t otel-nginx-test/nginx -f test/Dockerfile .
+docker build -t otel-nginx-test/express-backend -f test/backend/simple_express/Dockerfile test/backend/simple_express
+cd test/instrumentation
 mix test
 ```

--- a/instrumentation/nginx/ci/grpc.sh
+++ b/instrumentation/nginx/ci/grpc.sh
@@ -4,7 +4,9 @@ set -e
 
 mkdir -p grpc/cmake/build
 cd grpc/cmake/build
-cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF \
+cmake -DgRPC_INSTALL=ON \
+  -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/grpc \
+  -DgRPC_BUILD_TESTS=OFF \
   -DgRPC_ZLIB_PROVIDER=package \
   -DgRPC_SSL_PROVIDER=package \
   -DgRPC_RE2_PROVIDER=package \

--- a/instrumentation/nginx/ci/grpc.sh
+++ b/instrumentation/nginx/ci/grpc.sh
@@ -5,7 +5,6 @@ set -e
 mkdir -p grpc/cmake/build
 cd grpc/cmake/build
 cmake -DgRPC_INSTALL=ON \
-  -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/grpc \
   -DgRPC_BUILD_TESTS=OFF \
   -DgRPC_ZLIB_PROVIDER=package \
   -DgRPC_SSL_PROVIDER=package \

--- a/instrumentation/nginx/ci/otel-cpp.sh
+++ b/instrumentation/nginx/ci/otel-cpp.sh
@@ -5,8 +5,7 @@ set -e
 cd opentelemetry-cpp
 mkdir build
 cd build
-cmake -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/install" \
-  -DWITH_OTLP=ON \
+cmake -DWITH_OTLP=ON \
   -DBUILD_TESTING=OFF \
   -DWITH_EXAMPLES=OFF \
   -DCMAKE_POSITION_INDEPENDENT_CODE=ON ..

--- a/instrumentation/nginx/ci/otel-cpp.sh
+++ b/instrumentation/nginx/ci/otel-cpp.sh
@@ -5,6 +5,10 @@ set -e
 cd opentelemetry-cpp
 mkdir build
 cd build
-cmake -DWITH_OTLP=ON -DBUILD_TESTING=OFF -DWITH_EXAMPLES=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON ..
+cmake -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/install" \
+  -DWITH_OTLP=ON \
+  -DBUILD_TESTING=OFF \
+  -DWITH_EXAMPLES=OFF \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON ..
 make -j2
 sudo make install

--- a/instrumentation/nginx/src/location_config.h
+++ b/instrumentation/nginx/src/location_config.h
@@ -11,6 +11,7 @@ struct OtelNgxLocationConf {
   ngx_flag_t enabled = NGX_CONF_UNSET;
   TracePropagationType propagationType = TracePropagationW3C;
   NgxCompiledScript operationNameScript;
+  ngx_array_t* customAttributes = nullptr;
 };
 
 inline OtelNgxLocationConf* GetOtelLocationConf(ngx_http_request_t* req) {

--- a/instrumentation/nginx/src/otel_ngx_module.cpp
+++ b/instrumentation/nginx/src/otel_ngx_module.cpp
@@ -355,18 +355,18 @@ static char* MergeLocConf(ngx_conf_t*, void* parent, void* child) {
   if (prev->customAttributes && !conf->customAttributes) {
     conf->customAttributes = prev->customAttributes;
   } else if (prev->customAttributes && conf->customAttributes) {
-    std::unordered_map<nostd::string_view, CompiledScriptAttribute*> mergedAttributes;
+    std::unordered_map<nostd::string_view, CompiledScriptAttribute> mergedAttributes;
 
     for (ngx_uint_t i = 0; i < prev->customAttributes->nelts; i++) {
       CompiledScriptAttribute* attrib =
         &((CompiledScriptAttribute*)prev->customAttributes->elts)[i];
-      mergedAttributes[FromNgxString(attrib->key.pattern)] = attrib;
+      mergedAttributes[FromNgxString(attrib->key.pattern)] = *attrib;
     }
 
     for (ngx_uint_t i = 0; i < conf->customAttributes->nelts; i++) {
       CompiledScriptAttribute* attrib =
         &((CompiledScriptAttribute*)conf->customAttributes->elts)[i];
-      mergedAttributes[FromNgxString(attrib->key.pattern)] = attrib;
+      mergedAttributes[FromNgxString(attrib->key.pattern)] = *attrib;
     }
 
     ngx_uint_t index = 0;
@@ -379,12 +379,14 @@ static char* MergeLocConf(ngx_conf_t*, void* parent, void* child) {
           return (char*)NGX_CONF_ERROR;
         }
 
-        *attribute = *kv.second;
+        *attribute = kv.second;
       } else {
         CompiledScriptAttribute* attributes =
           (CompiledScriptAttribute*)conf->customAttributes->elts;
-        attributes[index++] = *kv.second;
+        attributes[index] = kv.second;
       }
+
+      index++;
     }
   }
 

--- a/instrumentation/nginx/src/otel_ngx_module.cpp
+++ b/instrumentation/nginx/src/otel_ngx_module.cpp
@@ -1,6 +1,7 @@
 #include <opentelemetry/nostd/mpark/variant.h>
 #include <opentelemetry/sdk/trace/processor.h>
 #include <opentelemetry/trace/span.h>
+#include <unordered_map>
 #include <vector>
 
 extern "C" {
@@ -29,27 +30,15 @@ namespace nostd = opentelemetry::nostd;
 namespace sdktrace = opentelemetry::sdk::trace;
 namespace otlp = opentelemetry::exporter::otlp;
 
-struct OtelNgxScriptAttribute {
-  OtelNgxScriptAttribute(nostd::string_view attribute, nostd::string_view script)
-    : attribute(ToNgxString(attribute)), script(ToNgxString(script)) {}
-  ngx_str_t attribute;
-  ngx_str_t script;
-};
-
 constexpr char kOtelCtxVarPrefix[] = "otel_ctxvar_";
 
-const OtelNgxScriptAttribute kDefaultScriptAttributes[] = {
+const ScriptAttributeDeclaration kDefaultScriptAttributes[] = {
   {"http.scheme", "$scheme"},
 };
 
 struct OtelMainConf {
   ngx_array_t* scriptAttributes;
   OtelNgxAgentConfig agentConfig;
-};
-
-struct ScriptAttribute {
-  NgxCompiledScript key;
-  NgxCompiledScript value;
 };
 
 nostd::shared_ptr<trace::Tracer> GetTracer() {
@@ -70,7 +59,7 @@ nostd::string_view NgxHttpFlavor(ngx_http_request_t* req) {
 }
 
 static ngx_int_t OtelGetContextVar(ngx_http_request_t*, ngx_http_variable_value_t*, uintptr_t) {
-  // Filled out on cotext creation.
+  // Filled out on context creation.
   return NGX_OK;
 }
 
@@ -245,9 +234,14 @@ ngx_int_t StartNgxSpan(ngx_http_request_t* req) {
 
 void AddScriptAttributes(
   trace::Span* span, const ngx_array_t* attributes, ngx_http_request_t* req) {
-  ScriptAttribute* elements = (ScriptAttribute*)attributes->elts;
+
+  if (!attributes) {
+    return;
+  }
+
+  CompiledScriptAttribute* elements = (CompiledScriptAttribute*)attributes->elts;
   for (ngx_uint_t i = 0; i < attributes->nelts; i++) {
-    ScriptAttribute* attribute = &elements[i];
+    CompiledScriptAttribute* attribute = &elements[i];
     ngx_str_t key = ngx_null_string;
     ngx_str_t value = ngx_null_string;
 
@@ -272,28 +266,12 @@ ngx_int_t FinishNgxSpan(ngx_http_request_t* req) {
   span->SetAttribute("http.status_code", req->headers_out.status);
 
   AddScriptAttributes(span.get(), GetOtelMainConf(req)->scriptAttributes, req);
+  AddScriptAttributes(span.get(), GetOtelLocationConf(req)->customAttributes, req);
 
   span->UpdateName(GetOperationName(req));
 
   span->End();
   return NGX_DECLINED;
-}
-
-bool RegisterScriptAttribute(
-  ngx_conf_t* conf, ngx_array_t* attributes, OtelNgxScriptAttribute attrib) {
-  ScriptAttribute* scriptAttrib = (ScriptAttribute*)ngx_array_push(attributes);
-
-  if (scriptAttrib == nullptr) {
-    return false;
-  }
-
-  new (scriptAttrib) ScriptAttribute();
-
-  if (!CompileScript(conf, attrib.attribute, &scriptAttrib->key)) {
-    return false;
-  }
-
-  return CompileScript(conf, attrib.script, &scriptAttrib->value);
 }
 
 static ngx_int_t InitModule(ngx_conf_t* conf) {
@@ -330,14 +308,23 @@ static ngx_int_t InitModule(ngx_conf_t* conf) {
 
   otelMainConf->scriptAttributes = ngx_array_create(
     conf->pool, sizeof(kDefaultScriptAttributes) / sizeof(kDefaultScriptAttributes[0]),
-    sizeof(ScriptAttribute));
+    sizeof(CompiledScriptAttribute));
 
   if (otelMainConf->scriptAttributes == nullptr) {
     return NGX_ERROR;
   }
 
-  for (const auto& scriptAttribute : kDefaultScriptAttributes) {
-    if (!RegisterScriptAttribute(conf, otelMainConf->scriptAttributes, scriptAttribute)) {
+  for (const auto& attrib : kDefaultScriptAttributes) {
+    CompiledScriptAttribute* compiledAttrib =
+      (CompiledScriptAttribute*)ngx_array_push(otelMainConf->scriptAttributes);
+
+    if (compiledAttrib == nullptr) {
+      return false;
+    }
+
+    new (compiledAttrib) CompiledScriptAttribute();
+
+    if (!CompileScriptAttribute(conf, attrib, compiledAttrib)) {
       return NGX_ERROR;
     }
   }
@@ -364,6 +351,42 @@ static char* MergeLocConf(ngx_conf_t*, void* parent, void* child) {
   OtelNgxLocationConf* conf = (OtelNgxLocationConf*)child;
 
   ngx_conf_merge_value(conf->enabled, prev->enabled, 1);
+
+  if (prev->customAttributes && !conf->customAttributes) {
+    conf->customAttributes = prev->customAttributes;
+  } else if (prev->customAttributes && conf->customAttributes) {
+    std::unordered_map<nostd::string_view, CompiledScriptAttribute*> mergedAttributes;
+
+    for (ngx_uint_t i = 0; i < prev->customAttributes->nelts; i++) {
+      CompiledScriptAttribute* attrib =
+        &((CompiledScriptAttribute*)prev->customAttributes->elts)[i];
+      mergedAttributes[FromNgxString(attrib->key.pattern)] = attrib;
+    }
+
+    for (ngx_uint_t i = 0; i < conf->customAttributes->nelts; i++) {
+      CompiledScriptAttribute* attrib =
+        &((CompiledScriptAttribute*)conf->customAttributes->elts)[i];
+      mergedAttributes[FromNgxString(attrib->key.pattern)] = attrib;
+    }
+
+    ngx_uint_t index = 0;
+    for (const auto& kv : mergedAttributes) {
+      if (index == conf->customAttributes->nelts) {
+        CompiledScriptAttribute* attribute =
+          (CompiledScriptAttribute*)ngx_array_push(conf->customAttributes);
+
+        if (!attribute) {
+          return (char*)NGX_CONF_ERROR;
+        }
+
+        *attribute = *kv.second;
+      } else {
+        CompiledScriptAttribute* attributes =
+          (CompiledScriptAttribute*)conf->customAttributes->elts;
+        attributes[index++] = *kv.second;
+      }
+    }
+  }
 
   return NGX_CONF_OK;
 }
@@ -501,6 +524,34 @@ char* OtelNgxSetConfig(ngx_conf_t* conf, ngx_command_t*, void*) {
   return NGX_CONF_OK;
 }
 
+static char* OtelNgxSetCustomAttribute(ngx_conf_t* conf, ngx_command_t*, void* userConf) {
+  OtelNgxLocationConf* locConf = (OtelNgxLocationConf*)userConf;
+
+  if (!locConf->customAttributes) {
+    locConf->customAttributes = ngx_array_create(conf->pool, 1, sizeof(CompiledScriptAttribute));
+
+    if (!locConf->customAttributes) {
+      return (char*)NGX_CONF_ERROR;
+    }
+  }
+
+  CompiledScriptAttribute* compiledAttribute =
+    (CompiledScriptAttribute*)ngx_array_push(locConf->customAttributes);
+
+  if (!compiledAttribute) {
+    return (char*)NGX_CONF_ERROR;
+  }
+
+  ngx_str_t* args = (ngx_str_t*)conf->args->elts;
+
+  ScriptAttributeDeclaration attrib{args[1], args[2]};
+  if (!CompileScriptAttribute(conf, attrib, compiledAttribute)) {
+    return (char*)NGX_CONF_ERROR;
+  }
+
+  return NGX_CONF_OK;
+}
+
 static ngx_command_t kOtelNgxCommands[] = {
   {
     ngx_string("opentelemetry_propagate"),
@@ -522,6 +573,14 @@ static ngx_command_t kOtelNgxCommands[] = {
     ngx_string("opentelemetry_config"),
     NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
     OtelNgxSetConfig,
+    NGX_HTTP_LOC_CONF_OFFSET,
+    0,
+    nullptr,
+  },
+  {
+    ngx_string("opentelemetry_attribute"),
+    NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2,
+    OtelNgxSetCustomAttribute,
     NGX_HTTP_LOC_CONF_OFFSET,
     0,
     nullptr,

--- a/instrumentation/nginx/src/script.cpp
+++ b/instrumentation/nginx/src/script.cpp
@@ -24,3 +24,12 @@ bool CompileScript(ngx_conf_t* conf, ngx_str_t pattern, NgxCompiledScript* scrip
   return ngx_http_script_compile(&compilation) == NGX_OK;
 }
 
+bool CompileScriptAttribute(
+  ngx_conf_t* conf, ScriptAttributeDeclaration declaration,
+  CompiledScriptAttribute* compiledAttribute) {
+  if (!CompileScript(conf, declaration.attribute, &compiledAttribute->key)) {
+    return false;
+  }
+
+  return CompileScript(conf, declaration.script, &compiledAttribute->value);
+}

--- a/instrumentation/nginx/src/script.h
+++ b/instrumentation/nginx/src/script.h
@@ -6,6 +6,8 @@ extern "C" {
 #include <ngx_http.h>
 }
 
+#include "nginx_utils.h"
+
 struct NgxCompiledScript {
   ngx_str_t pattern = ngx_null_string;
   ngx_array_t* lengths = nullptr;
@@ -26,5 +28,24 @@ struct NgxCompiledScript {
   }
 };
 
-bool CompileScript(ngx_conf_t* conf, ngx_str_t pattern, NgxCompiledScript* script);
+struct ScriptAttributeDeclaration {
+  ScriptAttributeDeclaration(
+    opentelemetry::nostd::string_view attribute, opentelemetry::nostd::string_view script)
+    : attribute(ToNgxString(attribute)), script(ToNgxString(script)) {}
 
+  ScriptAttributeDeclaration(ngx_str_t attribute, ngx_str_t script)
+    : attribute(attribute), script(script) {}
+
+  ngx_str_t attribute;
+  ngx_str_t script;
+};
+
+struct CompiledScriptAttribute {
+  NgxCompiledScript key;
+  NgxCompiledScript value;
+};
+
+bool CompileScript(ngx_conf_t* conf, ngx_str_t pattern, NgxCompiledScript* script);
+bool CompileScriptAttribute(
+  ngx_conf_t* conf, ScriptAttributeDeclaration declaration,
+  CompiledScriptAttribute* compiledAttribute);

--- a/instrumentation/nginx/test/conf/nginx.conf
+++ b/instrumentation/nginx/test/conf/nginx.conf
@@ -43,10 +43,6 @@ http {
       return 200 "";
     }
 
-    location /globalattrib {
-      return 200 "";
-    }
-
     location /files/ {
       opentelemetry_operation_name file_access;
       try_files $uri =404; 

--- a/instrumentation/nginx/test/conf/nginx.conf
+++ b/instrumentation/nginx/test/conf/nginx.conf
@@ -17,6 +17,9 @@ http {
 
     root /var/www/html;
 
+    opentelemetry_attribute "test.attrib.global" "global";
+    opentelemetry_attribute "test.attrib.custom" "global-custom";
+
     location = / {
       opentelemetry_operation_name simple_backend;
       opentelemetry_propagate;
@@ -32,6 +35,16 @@ http {
     location = /off {
       opentelemetry off;
       proxy_pass http://node-backend/off;
+    }
+
+    location /attrib {
+      opentelemetry_attribute "test.attrib.script" "$msec";
+      opentelemetry_attribute "test.attrib.custom" "local";
+      return 200 "";
+    }
+
+    location /globalattrib {
+      return 200 "";
     }
 
     location /files/ {

--- a/instrumentation/nginx/test/instrumentation/test/instrumentation_test.exs
+++ b/instrumentation/nginx/test/instrumentation/test/instrumentation_test.exs
@@ -292,4 +292,17 @@ defmodule InstrumentationTest do
 
     assert status == 200
   end
+
+  test "Spans with custom attributes are produced", %{
+    trace_file: trace_file
+  } do
+    %HTTPoison.Response{status_code: status} = HTTPoison.get!("#{@host}/attrib")
+    [trace] = read_traces(trace_file, 1)
+    [span] = collect_spans(trace)
+    assert attrib(span, "test.attrib.custom") == "local"
+    assert attrib(span, "test.attrib.global") == "global"
+    assert attrib(span, "test.attrib.script") =~ ~r/\d+\.\d+/
+    assert status == 200
+  end
+
 end


### PR DESCRIPTION
Support adding user specified span attributes via nginx configuration, i.e. `opentelemetry_attribute "my.custom.attribute" "foobar";`. nginx variables can be used to set or combine the attribute values, for example `opentelemetry_attribute "my.custom.attribute" "user:$http_user_agent time:$msec";`.