### PR TITLE
Create CODEOWNERS 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,7 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @ThomsonTan @seemk @TomRoSystems @jsuereth @maxgolov @lalitb @pyohannes
+* @open-telemetry/cpp-contrib-approvers
+
+instrumentation/httpd/* @TomRoSystems @open-telemetry/cpp-contrib-approvers
+instrumentation/nginx/* @seemk @open-telemetry/cpp-contrib-approvers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @open-telemetry/cpp-approvers @lalitb
+* @ThomsonTan @jsuereth @maxgolov @lalitb @pyohannes 
 
-instrumentation/httpd/* @open-telemetry/cpp-approvers @seemk @TomRoSystems @lalitb
-instrumentation/nginx/* @open-telemetry/cpp-approvers @seemk @TomRoSystems @lalitb
+instrumentation/httpd/* @seemk @TomRoSystems @ThomsonTan @jsuereth @maxgolov @lalitb @pyohannes
+instrumentation/nginx/* @seemk @TomRoSystems @ThomsonTan @jsuereth @maxgolov @lalitb @pyohannes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# Learn about CODEOWNERS file format:
+#  https://help.github.com/en/articles/about-code-owners
+#
+
+* @open-telemetry/cpp-approvers @lalitb
+
+instrumentation/httpd/* @open-telemetry/cpp-approvers @seemk @TomRoSystems @lalitb
+instrumentation/nginx/* @open-telemetry/cpp-approvers @seemk @TomRoSystems @lalitb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,5 @@
 
 * @open-telemetry/cpp-contrib-approvers
 
-instrumentation/httpd/* @TomRoSystems @open-telemetry/cpp-contrib-approvers
-instrumentation/nginx/* @seemk @open-telemetry/cpp-contrib-approvers
+instrumentation/httpd/ @TomRoSystems @open-telemetry/cpp-contrib-approvers
+instrumentation/nginx/ @seemk @open-telemetry/cpp-contrib-approvers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @ThomsonTan @jsuereth @maxgolov @lalitb @pyohannes 
-
-instrumentation/httpd/* @seemk @TomRoSystems @ThomsonTan @jsuereth @maxgolov @lalitb @pyohannes
-instrumentation/nginx/* @seemk @TomRoSystems @ThomsonTan @jsuereth @maxgolov @lalitb @pyohannes
+* @ThomsonTan @seemk @TomRoSystems @jsuereth @maxgolov @lalitb @pyohannes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenTelemetry C++ Contrib
 
-This is a repository for OpenTelemetry C++ contributions that are not part of the [core repository](https://github.com/open-telemetry/opentelemetry-cpp) and core distribution of the API and SDK.
+This is a repository for OpenTelemetry C++ contributions that are not part of the [core repository](https://github.com/open-telemetry/opentelemetry-cpp) of the API and SDK.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,9 @@
 # OpenTelemetry C++ Contrib
 
-This repository contains set of components extending functionality of the
-OpenTelemetry SDK. Instrumentation libraries, exporters, and other components
-can find their home here.
+This is a repository for OpenTelemetry C++ contributions that are not part of the [core repository](https://github.com/open-telemetry/opentelemetry-cpp) and core distribution of the API and SDK.
 
 ## Contributing
 
-For information on how to contribute, consult [the contributing
-guidelines](./CONTRIBUTING.md)
+News PRs will be automatically associated with the reviewers based on [CODEOWNERS](./.github/CODEOWNERS). PRs will be also automatically assigned to one of the maintainers or approvers for facilitation.
 
-## Support
-
-This repository accepts public contributions. Individual components are
-developed by numerous contributors. Approvers and maintainers of the main
-OpenTelemetry C++ SDK repository are not expected to directly contribute
-to every component.
-
-GitHub `CODEOWNER`S file is a simple way to automate away some of the pain
-associated with the review system on github, by automatically assigning
-reviewers to a pull request based on which files were modified. Individual
-components are encouraged to propose changes to `CODEOWNER`S file following
-the process [described here](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners).
-
-This repository is great for community supported components. Vendor specific
-code that requires a higher supportability guarantees needs to be placed in
-vendor's repository. Packages in vendor repositories would be prefixed with the
-vendor name to signify the difference from community-supported components.
+The facilitator is responsible for helping the PR author and reviewers to make progress or if progress cannot be made for closing the PR. The facilitators will typically rely on codeowner's detailed review of the code when making the final approval decision.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,28 @@
 # OpenTelemetry C++ Contrib
 
-This is a repository for OpenTelemetry C++ contributions that are not part of the [core repository](https://github.com/open-telemetry/opentelemetry-cpp) of the API and SDK.
+This repository contains set of components extending functionality of the
+OpenTelemetry SDK. Instrumentation libraries, exporters, and other components
+can find their home here.
 
 ## Contributing
 
-News PRs will be automatically associated with the reviewers based on [CODEOWNERS](./.github/CODEOWNERS). PRs will be also automatically assigned to one of the maintainers or approvers for facilitation.
+For information on how to contribute, consult [the contributing
+guidelines](./CONTRIBUTING.md)
 
-The facilitator is responsible for helping the PR author and reviewers to make progress or if progress cannot be made for closing the PR. The facilitators will typically rely on codeowner's detailed review of the code when making the final approval decision.
+## Support
+
+This repository accepts public contributions. Individual components are
+developed by numerous contributors. Approvers and maintainers of the main
+OpenTelemetry C++ SDK repository are not expected to directly contribute
+to every component.
+
+GitHub `CODEOWNER`S file is a simple way to automate away some of the pain
+associated with the review system on github, by automatically assigning
+reviewers to a pull request based on which files were modified. Individual
+components are encouraged to propose changes to `CODEOWNER`S file following
+the process [described here](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners).
+
+This repository is great for community supported components. Vendor specific
+code that requires a higher supportability guarantees needs to be placed in
+vendor's repository. Packages in vendor repositories would be prefixed with the
+vendor name to signify the difference from community-supported components.


### PR DESCRIPTION

As of now, it's individual aliases in the CODEOWNERS file.  I have taken liberty to take current approvers from core repo, along with @seemk and @TomRoSystems and make them default code owner. We can start adding component level owners once the repo grows.

Please raise a comment here if someone doesn't want to be in list, or would like to add someone here, or want to be owner of only specific component (currently nginx & httpd ) within repo ?

Once we all agree, we can raise request to create approver group accordingly.  Also whether we need to have separate approvers and maintainers, or let one of the default approvers be responsible to merge the changes once we have sufficient approvals. 

I can't find @seemk from Reviewers search list ( not sure why )  - Requesting him to please review, or if someone can add him as reviewer.



