### PR TITLE
Add path matching to nginx pull requests, fix nginx docker waiting

### DIFF
--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/nginx.yml'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'instrumentation/nginx/**'
+      - '.github/workflows/nginx.yml'
 
 jobs:
   nginx-build-test:

--- a/instrumentation/nginx/test/conf/nginx.conf
+++ b/instrumentation/nginx/test/conf/nginx.conf
@@ -26,6 +26,11 @@ http {
       proxy_pass http://node-backend/;
     }
 
+    location = /up {
+      opentelemetry off;
+      return 200 "ok\n";
+    }
+
     location = /b3 {
       opentelemetry_operation_name test_b3;
       opentelemetry_propagate b3;

--- a/instrumentation/nginx/test/instrumentation/test/instrumentation_test.exs
+++ b/instrumentation/nginx/test/instrumentation/test/instrumentation_test.exs
@@ -8,7 +8,25 @@ defmodule InstrumentationTest do
     Enum.find(lines, fn line -> String.match?(line, re) end) != nil
   end
 
-  def wait_until_ready(_, %{:collector => true, :express => true}), do: :ready
+  def poll_nginx(0), do: raise "Timed out waiting for nginx"
+
+  def poll_nginx(attempts_remaining) do
+    case HTTPoison.get("#{@host}/up") do
+      {:ok, %HTTPoison.Response{status_code: 200}} -> :ready
+      _ ->
+      Process.sleep(200)
+      poll_nginx(attempts_remaining - 1)
+    end
+  end
+
+  def wait_nginx() do
+    poll_nginx(30)
+  end
+
+  def wait_until_ready(_, %{:collector => true, :express => true, :nginx => false}) do
+    wait_nginx()
+    :ready
+  end
 
   def wait_until_ready(port, ctx) do
     receive do
@@ -23,7 +41,8 @@ defmodule InstrumentationTest do
           port,
           Map.merge(ctx, %{
             collector: has_collector,
-            express: has_express
+            express: has_express,
+            nginx: false
           })
         )
     after

--- a/instrumentation/nginx/test/instrumentation/test/instrumentation_test.exs
+++ b/instrumentation/nginx/test/instrumentation/test/instrumentation_test.exs
@@ -8,14 +8,16 @@ defmodule InstrumentationTest do
     Enum.find(lines, fn line -> String.match?(line, re) end) != nil
   end
 
-  def poll_nginx(0), do: raise "Timed out waiting for nginx"
+  def poll_nginx(0), do: raise("Timed out waiting for nginx")
 
   def poll_nginx(attempts_remaining) do
     case HTTPoison.get("#{@host}/up") do
-      {:ok, %HTTPoison.Response{status_code: 200}} -> :ready
+      {:ok, %HTTPoison.Response{status_code: 200}} ->
+        :ready
+
       _ ->
-      Process.sleep(200)
-      poll_nginx(attempts_remaining - 1)
+        Process.sleep(200)
+        poll_nginx(attempts_remaining - 1)
     end
   end
 
@@ -325,5 +327,4 @@ defmodule InstrumentationTest do
     assert attrib(span, "test.attrib.script") =~ ~r/\d+\.\d+/
     assert status == 200
   end
-
 end


### PR DESCRIPTION
The CI's path matching only triggered for pushes, but not PRs.

Also the tests now wait until nginx comes up, this caused flakiness before.