### PR TITLE
feat(nginx): read OTLP endpoint from env

### DIFF
--- a/instrumentation/nginx/README.md
+++ b/instrumentation/nginx/README.md
@@ -84,6 +84,7 @@ exporter = "otlp"
 processor = "batch"
 
 [exporters.otlp]
+# Alternatively the OTEL_EXPORTER_OTLP_ENDPOINT environment variable can also be used.
 host = "localhost"
 port = 4317
 

--- a/instrumentation/nginx/src/agent_config.cpp
+++ b/instrumentation/nginx/src/agent_config.cpp
@@ -17,6 +17,14 @@ static std::string FromStringDatum(toml_datum_t datum) {
 }
 
 static bool SetupOtlpExporter(toml_table_t* table, ngx_log_t* log, OtelNgxAgentConfig* config) {
+  const char *otel_exporter_otlp_endpoint_env = "OTEL_EXPORTER_OTLP_ENDPOINT";
+  auto endpoint_from_env = std::getenv(otel_exporter_otlp_endpoint_env);
+
+  if (endpoint_from_env) {
+    config->exporter.endpoint = endpoint_from_env;
+    return true;
+  }
+
   toml_datum_t hostVal = toml_string_in(table, "host");
   toml_datum_t portVal = toml_int_in(table, "port");
 
@@ -32,8 +40,7 @@ static bool SetupOtlpExporter(toml_table_t* table, ngx_log_t* log, OtelNgxAgentC
     return false;
   }
 
-  config->exporter.host = host;
-  config->exporter.port = portVal.u.i;
+  config->exporter.endpoint = host + ":" + std::to_string(portVal.u.i);;
 
   return true;
 }

--- a/instrumentation/nginx/src/agent_config.h
+++ b/instrumentation/nginx/src/agent_config.h
@@ -12,8 +12,7 @@ enum OtelProcessorType { OtelProcessorSimple, OtelProcessorBatch };
 struct OtelNgxAgentConfig {
   struct {
     OtelExporterType type = OtelExporterOTLP;
-    std::string host;
-    uint32_t port;
+    std::string endpoint;
   } exporter;
 
   struct {

--- a/instrumentation/nginx/src/otel_ngx_module.cpp
+++ b/instrumentation/nginx/src/otel_ngx_module.cpp
@@ -603,7 +603,7 @@ static std::unique_ptr<sdktrace::SpanExporter> CreateExporter(const OtelNgxAgent
 
   switch (conf->exporter.type) {
     case OtelExporterOTLP: {
-      std::string endpoint = conf->exporter.host + ":" + std::to_string(conf->exporter.port);
+      std::string endpoint = conf->exporter.endpoint;
       otlp::OtlpExporterOptions opts{endpoint};
       exporter.reset(new otlp::OtlpExporter(opts));
       break;


### PR DESCRIPTION
Support the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to configure the endpoint.

This is required when the collector is running as a daemonset on each node as the collector endpoint needs to be injected by k8s.

The variable is part of the standard configuration options https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options