### PR TITLE
Remove the OTLP receiver legacy gRPC port(55680) references

### DIFF
--- a/instrumentation/httpd/README.md
+++ b/instrumentation/httpd/README.md
@@ -38,7 +38,7 @@ __OpenTelemetryPath__
 This option specifies file to which to export when `file` exporter is used. If no `OpenTelemetryPath` is specified then spans goes to standard error output which is apache error log.
 
 __OpenTelemetryEndpoint__
-OpenTelemetryEndpoint specifies where to export spans when OTLP is used. Put hostname and then port. Example value: `host.docker.internal:55680`
+OpenTelemetryEndpoint specifies where to export spans when OTLP is used. Put hostname and then port. Example value: `host.docker.internal:4317`
 
 __OpenTelemetryBatch__
 This directive takes 3 numerical arguments for batch processing:

--- a/instrumentation/httpd/opentelemetry.conf
+++ b/instrumentation/httpd/opentelemetry.conf
@@ -9,7 +9,7 @@ OpenTelemetryExporter   file
 OpenTelemetryPath /tmp/output-spans
 
 # OpenTelemetryExporter   otlp
-# OpenTelemetryEndpoint host.docker.internal:55680
+# OpenTelemetryEndpoint host.docker.internal:4317
 
 # OpenTelemetryBatch for batch configuration. Takes 3 arguments:
 # Max Queue Size


### PR DESCRIPTION
**Description:**
The legacy gRPC port(55680) in OTLP Receiver will be disabled in OTel Collector before the collector GA.

This CR replaced all gRPC port occurrences from `55680` to `4317` in this repo.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2565