### PR TITLE
feat(nginx): bump otel SDK to v0.7.0

### DIFF
--- a/instrumentation/nginx/test/instrumentation/lib/mix/tasks/dockerfiles.ex
+++ b/instrumentation/nginx/test/instrumentation/lib/mix/tasks/dockerfiles.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Dockerfiles do
   use Mix.Task
 
   @grpc_version "v1.36.4"
-  @otel_cpp_version "v0.6.0"
+  @otel_cpp_version "v0.7.0"
 
   def run([out_dir | combos]) do
     out_dir_abs = Path.expand(out_dir)


### PR DESCRIPTION
Bump to https://github.com/open-telemetry/opentelemetry-cpp/releases/tag/v0.7.0

Fixes https://github.com/open-telemetry/opentelemetry-cpp-contrib/issues/27