### PR TITLE
fix(nginx): readme sampler name

### DIFF
--- a/instrumentation/nginx/README.md
+++ b/instrumentation/nginx/README.md
@@ -97,7 +97,7 @@ max_export_batch_size = 512
 name = "nginx-proxy" # Opentelemetry resource name
 
 [sampler]
-name = "AlwaysOn" # Also: AlwaysOff, TraceIdRatioBasedSampler
+name = "AlwaysOn" # Also: AlwaysOff, TraceIdRatioBased
 ratio = 0.1
 parent_based = false
 ```


### PR DESCRIPTION
Use the correct sampler name in the readme https://github.com/open-telemetry/opentelemetry-cpp-contrib/blob/main/instrumentation/nginx/src/agent_config.cpp#L167