### PR TITLE
NGINX instrumentation: add support for using SSL for OTLP, with an optional cert path

### DIFF
--- a/instrumentation/nginx/README.md
+++ b/instrumentation/nginx/README.md
@@ -87,6 +87,11 @@ processor = "batch"
 # Alternatively the OTEL_EXPORTER_OTLP_ENDPOINT environment variable can also be used.
 host = "localhost"
 port = 4317
+# Optionally enable SSL, for endpoints that support it
+# use_ssl = true
+# Optionally set a filesystem path to a pem file to be used for SSL encryption
+# (when use_ssl = true)
+# ssl_cert_path = "/path/to/cert.pem"
 
 [processors.batch]
 max_queue_size = 2048

--- a/instrumentation/nginx/README.md
+++ b/instrumentation/nginx/README.md
@@ -87,9 +87,9 @@ processor = "batch"
 # Alternatively the OTEL_EXPORTER_OTLP_ENDPOINT environment variable can also be used.
 host = "localhost"
 port = 4317
-# Optionally enable SSL, for endpoints that support it
+# Optional: enable SSL, for endpoints that support it
 # use_ssl = true
-# Optionally set a filesystem path to a pem file to be used for SSL encryption
+# Optional: set a filesystem path to a pem file to be used for SSL encryption
 # (when use_ssl = true)
 # ssl_cert_path = "/path/to/cert.pem"
 

--- a/instrumentation/nginx/src/agent_config.cpp
+++ b/instrumentation/nginx/src/agent_config.cpp
@@ -42,6 +42,16 @@ static bool SetupOtlpExporter(toml_table_t* table, ngx_log_t* log, OtelNgxAgentC
 
   config->exporter.endpoint = host + ":" + std::to_string(portVal.u.i);;
 
+  toml_datum_t useSSLVal = toml_bool_in(table, "use_ssl");
+  if (useSSLVal.ok) {
+    config->exporter.use_ssl_credentials = useSSLVal.u.b;
+
+    toml_datum_t certPathVal = toml_string_in(table, "ssl_cert_path");
+    if (certPathVal.ok) {
+      config->exporter.ssl_credentials_cacert_path = FromStringDatum(certPathVal);
+    }
+  }
+
   return true;
 }
 

--- a/instrumentation/nginx/src/agent_config.h
+++ b/instrumentation/nginx/src/agent_config.h
@@ -14,6 +14,8 @@ struct OtelNgxAgentConfig {
   struct {
     OtelExporterType type = OtelExporterOTLP;
     std::string endpoint;
+    bool use_ssl_credentials = false;
+    std::string ssl_credentials_cacert_path = "";
   } exporter;
 
   struct {

--- a/instrumentation/nginx/src/otel_ngx_module.cpp
+++ b/instrumentation/nginx/src/otel_ngx_module.cpp
@@ -610,6 +610,8 @@ static std::unique_ptr<sdktrace::SpanExporter> CreateExporter(const OtelNgxAgent
     case OtelExporterOTLP: {
       std::string endpoint = conf->exporter.endpoint;
       otlp::OtlpExporterOptions opts{endpoint};
+      opts.use_ssl_credentials = conf->exporter.use_ssl_credentials;
+      opts.ssl_credentials_cacert_path = conf->exporter.ssl_credentials_cacert_path;
       exporter.reset(new otlp::OtlpExporter(opts));
       break;
     }


### PR DESCRIPTION
This PR adds support for setting SSL-related options for the OTLP GRPC exporter for NGINX via the TOML config.

Suggestions for adding tests would be welcome.