### PR TITLE
nginx: upgrade to opentelemetry-cpp v1.0.0-rc1

### DIFF
--- a/instrumentation/nginx/CMakeLists.txt
+++ b/instrumentation/nginx/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(opentelemetry-cpp REQUIRED)
 find_package(Threads REQUIRED)
 find_package(protobuf REQUIRED)
 find_package(gRPC REQUIRED)
+find_package(CURL REQUIRED)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/nginx.cmake)
 
@@ -42,4 +43,5 @@ target_link_libraries(otel_ngx_module
   PRIVATE
   ${OPENTELEMETRY_CPP_LIBRARIES}
   gRPC::grpc++
+  CURL::libcurl
 )

--- a/instrumentation/nginx/src/otel_ngx_module.cpp
+++ b/instrumentation/nginx/src/otel_ngx_module.cpp
@@ -1,4 +1,3 @@
-#include <opentelemetry/nostd/mpark/variant.h>
 #include <opentelemetry/sdk/trace/processor.h>
 #include <opentelemetry/trace/span.h>
 #include <unordered_map>

--- a/instrumentation/nginx/src/propagate.cpp
+++ b/instrumentation/nginx/src/propagate.cpp
@@ -2,7 +2,6 @@
 #include "location_config.h"
 #include "nginx_utils.h"
 #include <opentelemetry/context/context_value.h>
-#include <opentelemetry/nostd/mpark/variant.h>
 #include <opentelemetry/trace/propagation/b3_propagator.h>
 #include <opentelemetry/trace/propagation/http_trace_context.h>
 #include <opentelemetry/trace/span.h>

--- a/instrumentation/nginx/test/instrumentation/lib/mix/tasks/dockerfiles.ex
+++ b/instrumentation/nginx/test/instrumentation/lib/mix/tasks/dockerfiles.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Dockerfiles do
   use Mix.Task
 
   @grpc_version "v1.36.4"
-  @otel_cpp_version "v0.7.0"
+  @otel_cpp_version "v1.0.0-rc1"
 
   def run([out_dir | combos]) do
     out_dir_abs = Path.expand(out_dir)


### PR DESCRIPTION
The latest RC brings in a dependency to curl even though it is not used yet.

Otherwise minor cleanup of include files.

Fixes #33 