### PR TITLE
Nginx without otel http

### DIFF
--- a/instrumentation/nginx/CMakeLists.txt
+++ b/instrumentation/nginx/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(Threads REQUIRED)
 find_package(protobuf REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(CURL REQUIRED)
-find_package(nlohmann_json REQUIRED)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/nginx.cmake)
 
@@ -45,5 +44,4 @@ target_link_libraries(otel_ngx_module
   ${OPENTELEMETRY_CPP_LIBRARIES}
   gRPC::grpc++
   CURL::libcurl
-  nlohmann_json::nlohmann_json
 )

--- a/instrumentation/nginx/test/instrumentation/lib/mix/tasks/dockerfiles.ex
+++ b/instrumentation/nginx/test/instrumentation/lib/mix/tasks/dockerfiles.ex
@@ -177,6 +177,7 @@ defmodule Mix.Tasks.Dockerfiles do
         -DCMAKE_INSTALL_PREFIX=/install \\
         -DCMAKE_PREFIX_PATH=/install \\
         -DWITH_OTLP=ON \\
+        -DWITH_OTLP_HTTP=OFF \\
         -DBUILD_TESTING=OFF \\
         -DWITH_EXAMPLES=OFF \\
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \\


### PR DESCRIPTION
Follow up from: https://github.com/open-telemetry/opentelemetry-cpp-contrib/pull/45

The OTEL HTTP exporter isn't used yet, so compile opentelemetry-cpp without it, which allows us to remove the nlohmann_json dependency.