### PR TITLE
nginx: rename and document context accessor variable

### DIFF
--- a/instrumentation/nginx/README.md
+++ b/instrumentation/nginx/README.md
@@ -170,7 +170,7 @@ The following nginx variables are set by the instrumentation:
 - `opentelemetry_context_traceparent` - [W3C trace
   context](https://www.w3.org/TR/trace-context/#trace-context-http-headers-format), e.g.: `00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01`
 - `opentelemetry_context_b3` - Trace context in the [B3
-  format](https://github.com/openzipkin/b3-propagation#single-header). Only set when using `opentelemetry propagate b3`.
+  format](https://github.com/openzipkin/b3-propagation#single-header). Only set when using `opentelemetry_propagate b3`.
 
 This can be used to add `Server-Timing` header:
 

--- a/instrumentation/nginx/README.md
+++ b/instrumentation/nginx/README.md
@@ -163,6 +163,21 @@ List of exported attributes and their corresponding nginx variables if applicabl
 - `http.scheme` - `$scheme`
 - `http.server_name` - From the `server_name` directive
 
+## nginx variables
+
+The following nginx variables are set by the instrumentation:
+
+- `opentelemetry_context_traceparent` - [W3C trace
+  context](https://www.w3.org/TR/trace-context/#trace-context-http-headers-format), e.g.: `00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01`
+- `opentelemetry_context_b3` - Trace context in the [B3
+  format](https://github.com/openzipkin/b3-propagation#single-header). Only set when using `opentelemetry propagate b3`.
+
+This can be used to add `Server-Timing` header:
+
+```
+add_header Server-Timing "traceparent;desc=\"$opentelemetry_context_traceparent\"";
+```
+
 ## Testing
 
 Dependencies:

--- a/instrumentation/nginx/test/conf/nginx.conf
+++ b/instrumentation/nginx/test/conf/nginx.conf
@@ -48,6 +48,11 @@ http {
       return 200 "";
     }
 
+    location /context {
+      add_header Context-TraceParent "$opentelemetry_context_traceparent";
+      return 200 "";
+    }
+
     location /files/ {
       opentelemetry_operation_name file_access;
       try_files $uri =404; 

--- a/instrumentation/nginx/test/instrumentation/test/instrumentation_test.exs
+++ b/instrumentation/nginx/test/instrumentation/test/instrumentation_test.exs
@@ -343,4 +343,20 @@ defmodule InstrumentationTest do
     assert attrib(span, "test.attrib.script") =~ ~r/\d+\.\d+/
     assert status == 200
   end
+
+  test "Accessing trace context", %{
+    trace_file: trace_file
+  } do
+    %HTTPoison.Response{status_code: status, headers: headers} =
+      HTTPoison.get!("#{@host}/context")
+
+    [trace] = read_traces(trace_file, 1)
+    [span] = collect_spans(trace)
+    {_, header_context} = Enum.find(headers, fn {k, _} -> k == "Context-TraceParent" end)
+    trace_id = span["traceId"]
+    span_id = span["spanId"]
+    context = "00-#{trace_id}-#{span_id}-01"
+    assert header_context == context
+    assert status == 200
+  end
 end


### PR DESCRIPTION
The trace context can now be accessed via `opentelemetry_context_traceparent` variable.

Updated docs and added a test for it.