### PR TITLE
Add support for alpine to nginx

### DIFF
--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [ubuntu-20.10, ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-20.10, ubuntu-20.04, ubuntu-18.04, alpine-3.14]
         nginx-rel: [mainline, stable]
     steps:
       - name: checkout otel nginx

--- a/instrumentation/nginx/CMakeLists.txt
+++ b/instrumentation/nginx/CMakeLists.txt
@@ -4,7 +4,7 @@ project(opentelemetry-nginx)
 
 find_package(opentelemetry-cpp REQUIRED)
 find_package(Threads REQUIRED)
-find_package(protobuf REQUIRED)
+find_package(Protobuf REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(CURL REQUIRED)
 


### PR DESCRIPTION
This adds support for alpine to the nginx plugin (there was an issue with the `Protobuf` package name, which needs to be capitalized), testing that distribution in CI.