### PR TITLE
protobuf package needs to be capitalized

### DIFF
--- a/instrumentation/httpd/CMakeLists.txt
+++ b/instrumentation/httpd/CMakeLists.txt
@@ -4,7 +4,7 @@ project(opentelemetry-httpd)
 
 find_package(opentelemetry-cpp REQUIRED)
 find_package(Threads REQUIRED)
-find_package(protobuf REQUIRED)
+find_package(Protobuf REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(CURL REQUIRED)
 find_package(Thrift REQUIRED)

--- a/instrumentation/nginx/CMakeLists.txt
+++ b/instrumentation/nginx/CMakeLists.txt
@@ -4,7 +4,7 @@ project(opentelemetry-nginx)
 
 find_package(opentelemetry-cpp REQUIRED)
 find_package(Threads REQUIRED)
-find_package(protobuf REQUIRED)
+find_package(Protobuf REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(CURL REQUIRED)
 


### PR DESCRIPTION
This capitalized the `Protobuf` package. While it seems on ubuntu, GCC doesn't care about the capital not being there, on Alpine, the package isn't found.