### PR TITLE
Add download location to usage docs

### DIFF
--- a/instrumentation/nginx/README.md
+++ b/instrumentation/nginx/README.md
@@ -17,6 +17,7 @@ Supported propagation types:
 
 Additional platforms and/or versions coming soon.
 
+
 ## Dependencies (for building)
 
 1. [gRPC](https://github.com/grpc/grpc) - currently the only supported exporter is OTLP. This requirement will be lifted
@@ -38,7 +39,7 @@ make
 
 ## Usage
 
-Modify nginx.conf, or see the [example](test/conf/nginx.conf)
+Download the .so file from the latest [GitHub Action run](https://github.com/open-telemetry/opentelemetry-cpp-contrib/actions/workflows/nginx.yml) or follow the instructions above to build. Then modify nginx.conf, or see the [example](test/conf/nginx.conf)
 
 ```
 load_module /path/to/otel_ngx_module.so;


### PR DESCRIPTION
I wanted to have a small conversation about the best place to include this. I came across this [in this issue comment](https://github.com/open-telemetry/opentelemetry-cpp-contrib/issues/16#issuecomment-820194434) and thought it would be better to formalize into the README to highlight that you didn't have to build it from scratch.

It would be nice if this was a binary from the 'Releases' section to make it even easier to download.

Finally, while I get that this is just pre-built from Ubuntu, is there any way to make it compatible with Debian as well? I have a `Dockerfile` that does this:

```
FROM nginx:1.21.3  # this is based on Debian
ADD modules/* /etc/nginx/modules
```

Then reference the .so file in a `load_module` directive. I get this error:

```
nginx: [emerg] dlopen() "/etc/nginx/modules/otel_ngx_module.so" failed (/lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /etc/nginx/modules/otel_ngx_module.so)) in /etc/nginx/common-outer-config.nginx.conf:1
```