### PR TITLE
nginx: Fix segfault

### DIFF
--- a/instrumentation/nginx/src/otel_ngx_module.cpp
+++ b/instrumentation/nginx/src/otel_ngx_module.cpp
@@ -404,13 +404,16 @@ ngx_int_t StartNgxSpan(ngx_http_request_t* req) {
       {"http.method", FromNgxString(req->method_name)},
       {"http.flavor", NgxHttpFlavor(req)},
       {"http.target", FromNgxString(req->unparsed_uri)},
-      {"http.host", FromNgxString(req->headers_in.host->value)},
     },
     startOpts);
 
   nostd::string_view serverName = GetNgxServerName(req);
   if (!serverName.empty()) {
     context->request_span->SetAttribute("http.server_name", serverName);
+  }
+
+  if (req->headers_in.host) {
+    context->request_span->SetAttribute("http.host", FromNgxString(req->headers_in.host->value));
   }
 
   if (req->headers_in.user_agent) {


### PR DESCRIPTION
`req->headers_in.host` can be `nullptr` if the client uses HTTP/1.0 and does send a `Host` header

GDB:
`bt`:
```
...
#10 StartNgxSpan (req=0x7f26ffabd720) at /tmp/build/opentelemetry-cpp-contrib-e30f1b6fcd7b74c84b97b5192579aa23510b87cb/instrumentation/nginx/src/otel_ngx_module.cpp:401
#11 0x000055d1bce8e4ed in ngx_http_core_rewrite_phase (r=0x7f26ffabd720, ph=<optimized out>) at src/http/ngx_http_core_module.c:932
...
```
`p *(ngx_http_request_t*)0x7f26ffabd720`
```
{..., header_in = 0x7f26fc0f6bf8, headers_in = {headers = {last = 0x7f26ffabd790, part = {
        elts = 0x7f26ffabecd0, nelts = 2, next = 0x0}, size = 48, nalloc = 20, pool = 0x7f26ffabd6d0}, host = 0x0, connection = 0x0, if_modified_since = 0x0, if_unmodified_since = 0x0, if_match = 0x0, if_none_match = 0x0, 
    user_agent = 0x7f26ffabecd0, referer = 0x0, content_length = 0x0, content_range = 0x0, content_type = 0x0, range = 0x0, if_range = 0x0, transfer_encoding = 0x0, te = 0x0, expect = 0x0, upgrade = 0x0, accept_encoding = 0x0, 
    via = 0x0, authorization = 0x0, keep_alive = 0x0, x_forwarded_for = {elts = 0x0, nelts = 0, size = 0, nalloc = 0, pool = 0x0}, x_real_ip = 0x0, accept = 0x7f26ffabed00, accept_language = 0x0, depth = 0x0, destination = 0x0, 
    overwrite = 0x0, date = 0x0, user = {len = 0, data = 0x0}, passwd = {len = 0, data = 0x0}, cookies = {elts = 0x0, nelts = 0, size = 0, nalloc = 0, pool = 0x0}, server = {len = 0, data = 0x0}, content_length_n = -1, 
    keep_alive_n = -1, connection_type = 0, chunked = 0, msie = 0, msie6 = 0, opera = 0, gecko = 0, chrome = 0, safari = 0, konqueror = 0}, ...}
```