### PR TITLE
fluentd exporter: Strip scheme for unix domain socket

### DIFF
--- a/exporters/fluentd/include/opentelemetry/exporters/fluentd/common/socket_tools.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/fluentd/common/socket_tools.h
@@ -249,8 +249,9 @@ struct SocketAddr {
 #ifdef HAVE_UNIX_DOMAIN
     if (isUnixDomain) {
       m_data_un.sun_family = AF_UNIX;
+      const char *unix_domain_path = ipAddress.data();
       // Max length of Unix domain filename is up to 108 chars
-      strncpy_s(m_data_un.sun_path, sizeof(m_data_un.sun_path), addr,
+      strncpy_s(m_data_un.sun_path, sizeof(m_data_un.sun_path), unix_domain_path,
                 sizeof(m_data_un.sun_path));
       return;
     }


### PR DESCRIPTION
The fluentd exporter expects the fluentd endpoint schema as `unix://` or `tcp://` based on the type of connection. For unix-domain connection, it doesn't strip the schema before creating a socket connection, and so the socket connection fails. This PR fixes it.
