### PR TITLE
cmake install configuration for fluentd-logger, and JSON install

### DIFF
--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -20,10 +20,12 @@ add_definitions(-DHAVE_CONSOLE_LOG)
 add_definitions(-DENABLE_LOGS_PREVIEW)
 find_package(opentelemetry-cpp REQUIRED)
 find_package(nlohmann_json QUIET)
+set(nlohmann_json_clone FALSE)
 if(nlohmann_json_FOUND)
   message("Using external nlohmann::json")
 else()
   include(cmake/nlohmann-json.cmake)
+  set(nlohmann_json_clone TRUE)
   message("\nnlohmann_json package was not found. Cloning from github")
 endif()
 
@@ -51,6 +53,12 @@ target_link_libraries(
   PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES}
   INTERFACE nlohmann_json::nlohmann_json)
 
+if(nlohmann_json_clone)
+  add_dependencies(opentelemetry_exporter_fluentd_trace nlohmann_json::nlohmann_json)
+  add_dependencies(opentelemetry_exporter_fluentd_logs nlohmann_json::nlohmann_json)
+  include_directories(${PROJECT_BINARY_DIR}/include)
+endif()
+  
 add_subdirectory(example)
 
 install(
@@ -90,6 +98,10 @@ if(BUILD_TESTING)
     opentelemetry_resources
     opentelemetry_exporter_fluentd_trace)
 
+  if(nlohmann_json_clone)
+    add_dependencies(fluentd_recordable_trace_test nlohmann_json::nlohmann_json)
+  endif()
+
   gtest_add_tests(
     TARGET fluentd_recordable_trace_test
     TEST_PREFIX exporter.
@@ -109,6 +121,10 @@ if(BUILD_TESTING)
     opentelemetry_resources
     opentelemetry_exporter_fluentd_logs)
 
+  if(nlohmann_json_clone)
+      add_dependencies(fluentd_recordable_logs_test nlohmann_json::nlohmann_json)
+    endif()
+    
   gtest_add_tests(
     TARGET fluentd_recordable_logs_test
     TEST_PREFIX exporter.

--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -77,7 +77,7 @@ install(
 
 install(
   DIRECTORY include/opentelemetry/exporters/fluentd/
-  DESTINATION include/opentelemetry/exporters/fluentd
+  DESTINATION include/opentelemetry/exporters/fluentd/
   FILES_MATCHING
   PATTERN "*.h")
 
@@ -124,7 +124,7 @@ if(BUILD_TESTING)
   if(nlohmann_json_clone)
       add_dependencies(fluentd_recordable_logs_test nlohmann_json::nlohmann_json)
     endif()
-    
+
   gtest_add_tests(
     TARGET fluentd_recordable_logs_test
     TEST_PREFIX exporter.

--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -19,7 +19,14 @@ project(opentelemetry-fluentd)
 add_definitions(-DHAVE_CONSOLE_LOG)
 add_definitions(-DENABLE_LOGS_PREVIEW)
 find_package(opentelemetry-cpp REQUIRED)
-find_package(nlohmann_json REQUIRED)
+find_package(nlohmann_json QUIET)
+if(nlohmann_json_FOUND)
+  message("Using external nlohmann::json")
+else()
+  include(cmake/nlohmann-json.cmake)
+  message("\nnlohmann_json package was not found. Cloning from github")
+endif()
+
 find_package(CURL REQUIRED)
 
 include_directories(include)
@@ -54,8 +61,15 @@ install(
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 install(
+  TARGETS opentelemetry_exporter_fluentd_logs
+  EXPORT "${PROJECT_NAME}-target"
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(
   DIRECTORY include/opentelemetry/exporters/fluentd/
-  DESTINATION include/opentelemetry/exporters/
+  DESTINATION include/opentelemetry/exporters/fluentd
   FILES_MATCHING
   PATTERN "*.h")
 

--- a/exporters/fluentd/cmake/nlohmann-json.cmake
+++ b/exporters/fluentd/cmake/nlohmann-json.cmake
@@ -1,0 +1,42 @@
+if("${nlohmann-json}" STREQUAL "")
+    set(nlohmann-json "develop")
+endif()
+include(ExternalProject)
+ExternalProject_Add(nlohmann_json_download
+    PREFIX third_party
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG
+        "${nlohmann-json}"
+    UPDATE_COMMAND ""
+    CMAKE_ARGS
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+      -DJSON_BuildTests=OFF
+      -DJSON_Install=ON
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    TEST_AFTER_INSTALL
+        0
+    DOWNLOAD_NO_PROGRESS
+        1
+    LOG_CONFIGURE
+        1
+    LOG_BUILD
+        1
+    LOG_INSTALL
+        1
+)
+
+ExternalProject_Get_Property(nlohmann_json_download INSTALL_DIR)
+SET(NLOHMANN_JSON_INCLUDE_DIR ${INSTALL_DIR}/third_party/src/nlohmann_json_download/single_include)
+add_library(nlohmann_json_ INTERFACE)
+target_include_directories(nlohmann_json_ INTERFACE
+    "$<BUILD_INTERFACE:${NLOHMANN_JSON_INCLUDE_DIR}>"
+    "$<INSTALL_INTERFACE:include>")
+add_dependencies(nlohmann_json_ nlohmann_json_download)
+add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json_)
+
+install(
+  TARGETS nlohmann_json_
+  EXPORT "${PROJECT_NAME}-target"
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/exporters/fluentd/cmake/nlohmann-json.cmake
+++ b/exporters/fluentd/cmake/nlohmann-json.cmake
@@ -1,9 +1,8 @@
 if("${nlohmann-json}" STREQUAL "")
-    set(nlohmann-json "develop")
+    set(nlohmann-json "v3.9.1")
 endif()
 include(ExternalProject)
 ExternalProject_Add(nlohmann_json_download
-    PREFIX third_party
     GIT_REPOSITORY https://github.com/nlohmann/json.git
     GIT_TAG
         "${nlohmann-json}"


### PR DESCRIPTION
This  adds
- cmake install configuration for fluentd logger
- Install nlohmann_json if missing ( copied from main repo ).
- Fix header install path to  `include/opentelemetry/exporters/fluentd` instead of `include/opentelemetry/exporters/`