### PR TITLE
Eable fluentd exporter to be used in other cmake project

### DIFF
--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -41,7 +41,6 @@ target_link_libraries(
   opentelemetry_exporter_fluentd_trace
   PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES}
   INTERFACE nlohmann_json::nlohmann_json)
-
 set_target_properties(opentelemetry_exporter_fluentd_trace PROPERTIES EXPORT_NAME trace)
 
 # create fluentd logs exporter
@@ -54,9 +53,7 @@ target_link_libraries(
   opentelemetry_exporter_fluentd_logs
   PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES}
   INTERFACE nlohmann_json::nlohmann_json)
-
 set_target_properties(opentelemetry_exporter_fluentd_logs PROPERTIES EXPORT_NAME logs)
-
 
 if(nlohmann_json_clone)
   add_dependencies(opentelemetry_exporter_fluentd_trace nlohmann_json::nlohmann_json)

--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -42,6 +42,8 @@ target_link_libraries(
   PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES}
   INTERFACE nlohmann_json::nlohmann_json)
 
+set_target_properties(opentelemetry_exporter_fluentd_trace PROPERTIES EXPORT_NAME trace)
+
 # create fluentd logs exporter
 
 add_library(opentelemetry_exporter_fluentd_logs src/log/fluentd_exporter.cc
@@ -52,6 +54,9 @@ target_link_libraries(
   opentelemetry_exporter_fluentd_logs
   PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES}
   INTERFACE nlohmann_json::nlohmann_json)
+
+set_target_properties(opentelemetry_exporter_fluentd_logs PROPERTIES EXPORT_NAME logs)
+
 
 if(nlohmann_json_clone)
   add_dependencies(opentelemetry_exporter_fluentd_trace nlohmann_json::nlohmann_json)
@@ -130,3 +135,37 @@ if(BUILD_TESTING)
     TEST_PREFIX exporter.
     TEST_LIST fluentd_recordable_logs_test)
 endif() # BUILD_TESTING
+
+# config file for find_packages(opentelemetry-cpp-fluentd CONFIG)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set(OPENTELEMETRY_CPP_FLUENTD_VERSION, "0.1.0")
+set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
+configure_package_config_file(
+    "${CMAKE_CURRENT_LIST_DIR}/cmake/opentelemetry-cpp-fluentd-config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    #PATH_VARS OPENTELEMETRY_CPP_FLUENTD_VERSION PROJECT_NAME INCLUDE_INSTALL_DIR CMAKE_INSTALL_LIBDIR
+    PATH_VARS PROJECT_NAME INCLUDE_INSTALL_DIR CMAKE_INSTALL_LIBDIR
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+# Write version file for find_packages(opentelemetry-cpp-fluentd CONFIG)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config-version.cmake"
+  VERSION ${OPENTELEMETRY_VERSION}
+  COMPATIBILITY ExactVersion)
+
+install(
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config-version.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+# Export all components
+export(
+  EXPORT "${PROJECT_NAME}-target"
+  NAMESPACE "${PROJECT_NAME}::"
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-target.cmake"
+)
+

--- a/exporters/fluentd/cmake/opentelemetry-cpp-fluentd-config.cmake.in
+++ b/exporters/fluentd/cmake/opentelemetry-cpp-fluentd-config.cmake.in
@@ -1,0 +1,66 @@
+#.rst:
+# opentelemetry-cpp-fluentd.config.cmake
+# --------
+#
+# Find the native opentelemetry-cpp-fluentd includes and library.
+#
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following variables:
+#
+# ::
+#
+#   OPENTELEMETRY_CPP_FLUENTD_INCLUDE_DIRS  - Include directories of opentelemetry-cpp-fluentd.
+#   OPENTELEMETRY_CPP_FLUENTD_LIBRARY_DIRS  - Link directories of opentelemetry-cpp-fluentd.
+#   OPENTELEMETRY_CPP_FLUENTD_LIBRARIES     - List of libraries when using opentelemetry-cpp-fluentd.
+#   OPENTELEMETRY_CPP_FLUENTD_FOUND         - True if opentelemetry-cpp-fluentd found.
+#   OPENTELEMETRY_CPP_FLUENTD_VERSION           - Version of opentelemetry-cpp-fluentd.
+#
+# ::
+#   opentelemetry-cpp-fluentd::trace                    - Imported target of opentelemetry-cpp-fluentd::trace
+#   opentelemetry-cpp::logs                             - Imported target of opentelemetry-cpp-fluentd::logs
+
+# =============================================================================
+# Copyright 2020 opentelemetry.
+#
+# Distributed under the Apache License (the "License"); see accompanying file
+# LICENSE for details.
+# =============================================================================
+set(OPENTELEMETRY_CPP_FLUENTD_VERSION
+    "@OPENTELEMETRY_CPP_FLUENTD_VERSION@"
+    CACHE STRING "opentelemetry-cpp-fluentd version" FORCE)
+
+@PACKAGE_INIT@
+
+message(OPENTELEMETRY_CPP_FLUENTD_VERSION)
+find_package(Threads)
+
+set_and_check(OPENTELEMETRY_CPP_FLUENTD_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set_and_check(OPENTELEMETRY_CPP_FLUENTD_LIBRARY_DIRS "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-target.cmake")
+
+set(OPENTELEMETRY_CPP_FLUENTD_LIBRARIES)
+
+set(_OPENTELEMETRY_CPP_FLUENTD_LIBRARIES_TEST_TARGETS
+        trace
+        logs)
+
+foreach(_TEST_TARGET IN LISTS _OPENTELEMETRY_CPP_LIBRARIES_TEST_TARGETS)
+        if(TARGET opentelemetry-fluentd-cpp::${_TEST_TARGET})
+                list(APPEND OPENTELEMETRY_CPP_LIBRARIES opentelemetry-cpp-fluentd::${_TEST_TARGET})
+        else()
+                message("Target not found: " ${_TEST_TARGET})
+        endif()
+endforeach()
+
+
+# handle the QUIETLY and REQUIRED arguments and set opentelemetry-cpp_FOUND to
+# TRUE if all variables listed contain valid results, e.g. valid file paths.
+include("FindPackageHandleStandardArgs")
+find_package_handle_standard_args(
+  ${CMAKE_FIND_PACKAGE_NAME}
+  FOUND_VAR ${CMAKE_FIND_PACKAGE_NAME}_FOUND
+  REQUIRED_VARS OPENTELEMETRY_CPP_FLUENTD_INCLUDE_DIRS OPENTELEMETRY_CPP_FLUENTD_LIBRARIES)

--- a/exporters/fluentd/cmake/opentelemetry-cpp-fluentd-config.cmake.in
+++ b/exporters/fluentd/cmake/opentelemetry-cpp-fluentd-config.cmake.in
@@ -48,9 +48,9 @@ set(_OPENTELEMETRY_CPP_FLUENTD_LIBRARIES_TEST_TARGETS
         trace
         logs)
 
-foreach(_TEST_TARGET IN LISTS _OPENTELEMETRY_CPP_LIBRARIES_TEST_TARGETS)
+foreach(_TEST_TARGET IN LISTS _OPENTELEMETRY_CPP_FLUENTD_LIBRARIES_TEST_TARGETS)
         if(TARGET opentelemetry-fluentd-cpp::${_TEST_TARGET})
-                list(APPEND OPENTELEMETRY_CPP_LIBRARIES opentelemetry-cpp-fluentd::${_TEST_TARGET})
+                list(APPEND OPENTELEMETRY_CPP_FLUENTD_LIBRARIES opentelemetry-cpp-fluentd::${_TEST_TARGET})
         else()
                 message("Target not found: " ${_TEST_TARGET})
         endif()


### PR DESCRIPTION
CMake configuration to allow fluentd exporter to be used in other cmake projects using:
```cmake
find_packages(opentelemetry-cpp-fluentd CONFIG)
```