### PR TITLE
nginx: Create map to store requests and their trace contexts

### DIFF
--- a/instrumentation/nginx/src/otel_ngx_module.cpp
+++ b/instrumentation/nginx/src/otel_ngx_module.cpp
@@ -331,7 +331,7 @@ void TraceContextCleanup(void* data) {
 
 void RequestContextMapCleanup(void* data) {
   std::unordered_map<ngx_http_request_t*, TraceContext*>* map = (std::unordered_map<ngx_http_request_t*, TraceContext*>*)data;
-  map->clear();
+  map->~unordered_map();
 }
 
 nostd::string_view GetOperationName(ngx_http_request_t* req) {

--- a/instrumentation/nginx/src/otel_ngx_module.cpp
+++ b/instrumentation/nginx/src/otel_ngx_module.cpp
@@ -179,15 +179,12 @@ TraceContext* GetTraceContext(ngx_http_request_t* req) {
   }
 
   std::unordered_map<ngx_http_request_t*, TraceContext*>* map = (std::unordered_map<ngx_http_request_t*, TraceContext*>*)val->data;
-  unsigned count = map->count(req);
-  if (count == 1) {
-    return map->at(req);
-  } else if (count > 1) {
-    ngx_log_error(NGX_LOG_ERR, req->connection->log, 0, "More than one TraceContext found for a request");
-    return nullptr;
-  }
-  ngx_log_error(NGX_LOG_ERR, req->connection->log, 0, "TraceContext not found");
-  return nullptr;
+auto it = map->find(req);
+if (it != map->end()) {
+  return it->second;
+}
+ngx_log_error(NGX_LOG_ERR, req->connection->log, 0, "TraceContext not found");
+return nullptr;
 }
 
 nostd::string_view WithoutOtelVarPrefix(ngx_str_t value) {

--- a/instrumentation/nginx/src/otel_ngx_module.cpp
+++ b/instrumentation/nginx/src/otel_ngx_module.cpp
@@ -179,7 +179,15 @@ TraceContext* GetTraceContext(ngx_http_request_t* req) {
   }
 
   std::unordered_map<ngx_http_request_t*, TraceContext*>* map = (std::unordered_map<ngx_http_request_t*, TraceContext*>*)val->data;
-  return map->at(req);
+  unsigned count = map->count(req);
+  if (count == 1) {
+    return map->at(req);
+  } else if (count > 1) {
+    ngx_log_error(NGX_LOG_ERR, req->connection->log, 0, "More than one TraceContext found for a request");
+    return nullptr;
+  }
+  ngx_log_error(NGX_LOG_ERR, req->connection->log, 0, "TraceContext not found");
+  return nullptr;
 }
 
 nostd::string_view WithoutOtelVarPrefix(ngx_str_t value) {


### PR DESCRIPTION
Nginx requests share variables with their subrequests so we should not create contexts without first checking if it is a subrequest. As the variable is shared between the requests, we can instead create a map that will record which request matches to which context so that we can retrieve the right tracing context when `FinishNgxSpan` is called.

This fixes #89.