### PR TITLE
Fix for nlohmann json install

### DIFF
--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -37,6 +37,9 @@ if(nlohmann_json_FOUND)
 else()
   include(cmake/nlohmann-json.cmake)
   set(nlohmann_json_clone TRUE)
+  set(nlohmann_json_SOURCE_DIR
+      "${CMAKE_SOURCE_DIR}/nlohmann_json/single_include")
+  include_directories(${nlohmann_json_SOURCE_DIR})
   message("\nnlohmann_json package was not found. Cloning from github")
 endif()
 

--- a/exporters/fluentd/cmake/nlohmann-json.cmake
+++ b/exporters/fluentd/cmake/nlohmann-json.cmake
@@ -3,9 +3,11 @@ if("${nlohmann-json}" STREQUAL "")
 endif()
 include(ExternalProject)
 ExternalProject_Add(nlohmann_json_download
+    PREFIX nlohmann_json
     GIT_REPOSITORY https://github.com/nlohmann/json.git
     GIT_TAG
         "${nlohmann-json}"
+    GIT_SHALLOW 1
     UPDATE_COMMAND ""
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
@@ -25,7 +27,7 @@ ExternalProject_Add(nlohmann_json_download
 )
 
 ExternalProject_Get_Property(nlohmann_json_download INSTALL_DIR)
-SET(NLOHMANN_JSON_INCLUDE_DIR ${INSTALL_DIR}/third_party/src/nlohmann_json_download/single_include)
+SET(NLOHMANN_JSON_INCLUDE_DIR ${INSTALL_DIR}/nlohmann_json/src/nlohmann_json_download/single_include)
 add_library(nlohmann_json_ INTERFACE)
 target_include_directories(nlohmann_json_ INTERFACE
     "$<BUILD_INTERFACE:${NLOHMANN_JSON_INCLUDE_DIR}>"


### PR DESCRIPTION
nlohman-json install path was incorrect ( missing PREFIX), fixed it. Also added include header directory rule at both target and system-level ( somehow arm cross-compiler build fails without that).

There are only two lines changed in cmake/nlohmann-json.cmake ( added line 6 for PREFIX, and fix NLOHMANN_JSON_INCLUDE_DIR directory path at line 30). Rest of the changes are coming from formatting.