### PR TITLE
small change missed out from #100

### DIFF
--- a/exporters/fluentd/cmake/nlohmann-json.cmake
+++ b/exporters/fluentd/cmake/nlohmann-json.cmake
@@ -5,6 +5,7 @@ include(ExternalProject)
 ExternalProject_Add(nlohmann_json_download
     PREFIX nlohmann_json
     GIT_REPOSITORY https://github.com/nlohmann/json.git
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/nlohmann_json"
     GIT_TAG
         "${nlohmann-json}"
     GIT_SHALLOW 1


### PR DESCRIPTION
Missed out on setting the nlohmann-json download location in #100. We are using that location as include directory for headers, so this is required.