### PR TITLE
Update CODEOWNERS for otel-webserver-module 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,4 @@
 
 instrumentation/httpd/ @TomRoSystems @open-telemetry/cpp-contrib-approvers
 instrumentation/nginx/ @seemk @open-telemetry/cpp-contrib-approvers
+instrumentation/otel-webserver-module/ @kpratyus @ajaynagariya @debajitdas @open-telemetry/cpp-contrib-approvers


### PR DESCRIPTION
- Add approvers for otel-webserver-module in CODEOWNERS
- Create an initial folder with an empty README.md