### PR TITLE
Opentelemetry version update for otel-webserver-module

### DIFF
--- a/instrumentation/otel-webserver-module/CHANGELOG.md
+++ b/instrumentation/otel-webserver-module/CHANGELOG.md
@@ -1,0 +1,3 @@
+## [1.0.0] 2021-03-16
+
+[Dependencies] Update Opentelemetry C++ SDK version to 1.2.0 from previous version 1.0.0-rc1 ([#115](https://github.com/open-telemetry/opentelemetry-cpp-contrib/pull/115/))

--- a/instrumentation/otel-webserver-module/CHANGELOG.md
+++ b/instrumentation/otel-webserver-module/CHANGELOG.md
@@ -1,3 +1,3 @@
-## [1.0.0] 2021-03-16
+## [1.0.0] 2022-03-10
 
 [Dependencies] Update Opentelemetry C++ SDK version to 1.2.0 from previous version 1.0.0-rc1 ([#115](https://github.com/open-telemetry/opentelemetry-cpp-contrib/pull/115/))

--- a/instrumentation/otel-webserver-module/Dockerfile
+++ b/instrumentation/otel-webserver-module/Dockerfile
@@ -172,23 +172,23 @@ RUN mkdir -p dependencies/apache-log4cxx/0.11.0 \
     && cd .. && rm -rf apache-log4cxx-0.11.0.tar.gz && rm -rf apache-log4cxx-0.11.0
 
 # install opentelemetry
-RUN mkdir -p dependencies/opentelemetry/1.0.0-rc1/lib \
-    && mkdir -p dependencies/opentelemetry/1.0.0-rc1/include \
+RUN mkdir -p dependencies/opentelemetry/1.2.0/lib \
+    && mkdir -p dependencies/opentelemetry/1.2.0/include \
     && git clone https://github.com/open-telemetry/opentelemetry-cpp \
     && cd opentelemetry-cpp/ \
-    && git checkout tags/v1.0.0-rc1 -b v1.0.0-rc1 \
+    && git checkout tags/v1.2.0 -b v1.2.0 \
     && git submodule update --init --recursive \
     && mkdir build \
     && cd build \
-    && cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON -DWITH_OTLP=ON -DCMAKE_INSTALL_PREFIX=/dependencies/opentelemetry/1.0.0-rc1 \
+    && cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON -DWITH_OTLP=ON -DCMAKE_INSTALL_PREFIX=/dependencies/opentelemetry/1.2.0 \
     && cmake --build . --target all \
     && cd .. \
-    && find . -name "*.so" -type f -exec cp {} /dependencies/opentelemetry/1.0.0-rc1/lib/ \; \
-    && cp build/libopentelemetry_proto.a /dependencies/opentelemetry/1.0.0-rc1/lib \
-    && cp -r api/include/ /dependencies/opentelemetry/1.0.0-rc1/ \
-    && for dir in exporters/*; do if [ -d "$dir" ]; then cp -rf "$dir/include" /dependencies/opentelemetry/1.0.0-rc1/; fi; done \
-    && cp -r sdk/include/ /dependencies/opentelemetry/1.0.0-rc1/ \
-    && cp -r build/generated/third_party/opentelemetry-proto/opentelemetry/proto/ /dependencies/opentelemetry/1.0.0-rc1/include/opentelemetry/ \
+    && find . -name "*.so" -type f -exec cp {} /dependencies/opentelemetry/1.2.0/lib/ \; \
+    && cp build/libopentelemetry_proto.a /dependencies/opentelemetry/1.2.0/lib \
+    && cp -r api/include/ /dependencies/opentelemetry/1.2.0/ \
+    && for dir in exporters/*; do if [ -d "$dir" ]; then cp -rf "$dir/include" /dependencies/opentelemetry/1.2.0/; fi; done \
+    && cp -r sdk/include/ /dependencies/opentelemetry/1.2.0/ \
+    && cp -r build/generated/third_party/opentelemetry-proto/opentelemetry/proto/ /dependencies/opentelemetry/1.2.0/include/opentelemetry/ \
     && cd .. && rm -rf opentelemetry-cpp
 
 # install googletest

--- a/instrumentation/otel-webserver-module/README.md
+++ b/instrumentation/otel-webserver-module/README.md
@@ -28,7 +28,7 @@ Monitoring individual modules is crucial to the instrumentation of Apache web se
 | Apr-util                                       | 1.6.1           |
 | Expat                                          | 2.3.0           |
 | Boost                                          | 1.75.0          |
-| Opentelemetry - C++ SDK                        | 1.0.0-rc1       |
+| Opentelemetry - C++ SDK                        | 1.2.0      |
 | Googletest                                     | 1.10.0          |
 
 *There are some libraries which are just used to generate Apache Header files

--- a/instrumentation/otel-webserver-module/build.gradle
+++ b/instrumentation/otel-webserver-module/build.gradle
@@ -169,11 +169,12 @@ task stageLibrary(type: Copy) {
 
     from("src/sdk_lib/src/api/include/appdynamics.h") { it.into "sdk_lib" }
     from(buildLibrary) { it.into "sdk_lib/lib" }
-    from("${modDepDir}/opentelemetry/1.0.0-rc1/lib/libopentelemetry_common.so") { it.into "sdk_lib/lib" }
-    from("${modDepDir}/opentelemetry/1.0.0-rc1/lib/libopentelemetry_resources.so") { it.into "sdk_lib/lib" }
-    from("${modDepDir}/opentelemetry/1.0.0-rc1/lib/libopentelemetry_trace.so") { it.into "sdk_lib/lib" }
-    from("${modDepDir}/opentelemetry/1.0.0-rc1/lib/libopentelemetry_exporter_ostream_span.so") { it.into "sdk_lib/lib" }
-    from("${modDepDir}/opentelemetry/1.0.0-rc1/lib/libopentelemetry_exporter_otprotocol.so") { it.into "sdk_lib/lib" }
+    from("${modDepDir}/opentelemetry/1.2.0/lib/libopentelemetry_common.so") { it.into "sdk_lib/lib" }
+    from("${modDepDir}/opentelemetry/1.2.0/lib/libopentelemetry_resources.so") { it.into "sdk_lib/lib" }
+    from("${modDepDir}/opentelemetry/1.2.0/lib/libopentelemetry_trace.so") { it.into "sdk_lib/lib" }
+    from("${modDepDir}/opentelemetry/1.2.0/lib/libopentelemetry_otlp_recordable.so") { it.into "sdk_lib/lib" }    
+    from("${modDepDir}/opentelemetry/1.2.0/lib/libopentelemetry_exporter_ostream_span.so") { it.into "sdk_lib/lib" }
+    from("${modDepDir}/opentelemetry/1.2.0/lib/libopentelemetry_exporter_otlp_grpc.so") { it.into "sdk_lib/lib" }
     from("dist/appdynamics_sdk_log4cxx.xml.template") { it.into "conf" }
     from("dist/install.${scriptExt}") { it.fileMode 0700 }
 

--- a/instrumentation/otel-webserver-module/opentelemetry_module.conf
+++ b/instrumentation/otel-webserver-module/opentelemetry_module.conf
@@ -1,8 +1,9 @@
 LoadFile /opt/opentelemetry-webserver-sdk/sdk_lib/lib/libopentelemetry_common.so
 LoadFile /opt/opentelemetry-webserver-sdk/sdk_lib/lib/libopentelemetry_resources.so
 LoadFile /opt/opentelemetry-webserver-sdk/sdk_lib/lib/libopentelemetry_trace.so
+LoadFile /opt/opentelemetry-webserver-sdk/sdk_lib/lib/libopentelemetry_otlp_recordable.so
 LoadFile /opt/opentelemetry-webserver-sdk/sdk_lib/lib/libopentelemetry_exporter_ostream_span.so
-LoadFile /opt/opentelemetry-webserver-sdk/sdk_lib/lib/libopentelemetry_exporter_otprotocol.so
+LoadFile /opt/opentelemetry-webserver-sdk/sdk_lib/lib/libopentelemetry_exporter_otlp_grpc.so
 
 #Load the ApacheModule SDK
 LoadFile /opt/opentelemetry-webserver-sdk/sdk_lib/lib/libopentelemetry_webserver_sdk.so

--- a/instrumentation/otel-webserver-module/src/build.gyp
+++ b/instrumentation/otel-webserver-module/src/build.gyp
@@ -51,11 +51,12 @@
           '$(ANSDK_DIR)/apache-log4cxx/0.11.0/lib/liblog4cxx.a',
           '$(ANSDK_DIR)/boost/1.75.0/lib/libboost_filesystem.a',
           '$(ANSDK_DIR)/boost/1.75.0/lib/libboost_system.a',
-          '$(ANSDK_DIR)/opentelemetry/1.0.0-rc1/lib/libopentelemetry_common.so',
-          '$(ANSDK_DIR)/opentelemetry/1.0.0-rc1/lib/libopentelemetry_resources.so',
-          '$(ANSDK_DIR)/opentelemetry/1.0.0-rc1/lib/libopentelemetry_trace.so',
-          '$(ANSDK_DIR)/opentelemetry/1.0.0-rc1/lib/libopentelemetry_exporter_ostream_span.so',
-          '$(ANSDK_DIR)/opentelemetry/1.0.0-rc1/lib/libopentelemetry_exporter_otprotocol.so'
+          '$(ANSDK_DIR)/opentelemetry/1.2.0/lib/libopentelemetry_common.so',
+          '$(ANSDK_DIR)/opentelemetry/1.2.0/lib/libopentelemetry_resources.so',
+          '$(ANSDK_DIR)/opentelemetry/1.2.0/lib/libopentelemetry_trace.so',
+          '$(ANSDK_DIR)/opentelemetry/1.2.0/lib/libopentelemetry_otlp_recordable.so',
+          '$(ANSDK_DIR)/opentelemetry/1.2.0/lib/libopentelemetry_exporter_ostream_span.so',
+          '$(ANSDK_DIR)/opentelemetry/1.2.0/lib/libopentelemetry_exporter_otlp_grpc.so'
         ],
 
         'include_dirs': [
@@ -64,7 +65,7 @@
           '$(ANSDK_DIR)/boost/1.75.0/include',
           '../include/util',
           '../include/core',
-          '$(ANSDK_DIR)/opentelemetry/1.0.0-rc1/include/',
+          '$(ANSDK_DIR)/opentelemetry/1.2.0/include/',
         ],
 
         'ldflags': [

--- a/instrumentation/otel-webserver-module/src/core/sdkwrapper/SdkHelperFactory.cpp
+++ b/instrumentation/otel-webserver-module/src/core/sdkwrapper/SdkHelperFactory.cpp
@@ -25,7 +25,7 @@
 #include "opentelemetry/sdk/trace/samplers/parent.h"
 #include "opentelemetry/sdk/trace/samplers/trace_id_ratio.h"
 #include "opentelemetry/sdk/resource/resource.h"
-#include "opentelemetry/exporters/otlp/otlp_exporter.h"
+#include "opentelemetry/exporters/otlp/otlp_grpc_exporter.h"
 #include "opentelemetry/baggage/propagation/baggage_propagator.h"
 #include <module_version.h>
 #include <fstream>
@@ -124,7 +124,7 @@ OtelSpanExporter SdkHelperFactory::GetExporter(
           LOG4CXX_WARN(mLogger, "Received unknown exporter type: " << type << ". Will create default(otlp) exporter");
           type = OTLP_EXPORTER_TYPE;
         }
-        opentelemetry::exporter::otlp::OtlpExporterOptions opts;
+        opentelemetry::exporter::otlp::OtlpGrpcExporterOptions opts;
         opts.endpoint = config->getOtelExporterEndpoint();
         if (config->getOtelSslEnabled()) {
             opts.use_ssl_credentials = config->getOtelSslEnabled();
@@ -132,7 +132,7 @@ OtelSpanExporter SdkHelperFactory::GetExporter(
             LOG4CXX_TRACE(mLogger, "Ssl Credentials are enabled for exporter, path: "
                 << opts.ssl_credentials_cacert_path);
         }
-        exporter.reset(new opentelemetry::exporter::otlp::OtlpExporter(opts));
+        exporter.reset(new opentelemetry::exporter::otlp::OtlpGrpcExporter(opts));
     }
 
     LOG4CXX_INFO(mLogger, "Exporter created with ExporterType: "

--- a/instrumentation/otel-webserver-module/test/ApacheTesting.sh
+++ b/instrumentation/otel-webserver-module/test/ApacheTesting.sh
@@ -16,8 +16,9 @@ echo '
 LoadFile /opt/appdynamics-sdk-native/sdk_lib/lib/libopentelemetry_common.so
 LoadFile /opt/appdynamics-sdk-native/sdk_lib/lib/libopentelemetry_resources.so
 LoadFile /opt/appdynamics-sdk-native/sdk_lib/lib/libopentelemetry_trace.so
+LoadFile /opt/appdynamics-sdk-native/sdk_lib/lib/libopentelemetry_otlp_recordable.so
 LoadFile /opt/appdynamics-sdk-native/sdk_lib/lib/libopentelemetry_exporter_ostream_span.so
-LoadFile /opt/appdynamics-sdk-native/sdk_lib/lib/libopentelemetry_exporter_otprotocol.so
+LoadFile /opt/appdynamics-sdk-native/sdk_lib/lib/libopentelemetry_exporter_otlp_grpc.so
 
 #Load the AppDynamics SDK
 LoadFile /opt/appdynamics-sdk-native/sdk_lib/lib/libappdynamics_native_sdk.so

--- a/instrumentation/otel-webserver-module/test/unit/unit_test.gyp
+++ b/instrumentation/otel-webserver-module/test/unit/unit_test.gyp
@@ -51,8 +51,9 @@
           '$(ANSDK_DIR)/opentelemetry/1.0.0-rc1/lib/libopentelemetry_common.so',
           '$(ANSDK_DIR)/opentelemetry/1.0.0-rc1/lib/libopentelemetry_resources.so',
           '$(ANSDK_DIR)/opentelemetry/1.0.0-rc1/lib/libopentelemetry_trace.so',
+          '$(ANSDK_DIR)/opentelemetry/1.0.0-rc1/lib/libopentelemetry_otlp_recordable.so',
           '$(ANSDK_DIR)/opentelemetry/1.0.0-rc1/lib/libopentelemetry_exporter_ostream_span.so',
-          '$(ANSDK_DIR)/opentelemetry/1.0.0-rc1/lib/libopentelemetry_exporter_otprotocol.so',
+          '$(ANSDK_DIR)/opentelemetry/1.0.0-rc1/lib/libopentelemetry_exporter_otlp_grpc.so',
        ],
 
         'ldflags': [


### PR DESCRIPTION
This PR deals with the issue https://github.com/open-telemetry/opentelemetry-cpp-contrib/issues/114 . The code has been updated with proper dependency and the Dockerfile has been updated with the updated build and installation instructions.