### PR TITLE
Fluentd exporter: Propagate build flags to external project for opentelemetry-cpp

### DIFF
--- a/exporters/fluentd/cmake/opentelemetry-cpp.cmake
+++ b/exporters/fluentd/cmake/opentelemetry-cpp.cmake
@@ -13,6 +13,8 @@ function(build_opentelemetry)
   set(opentelemetry_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/opentelemetry-cpp")
   set(opentelemetry_cpp_targets opentelemetry_trace opentelemetry_logs http_client_curl )
   set(opentelemetry_CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+	                       -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+	                       -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
 	 		       -DWITH_LOGS_PREVIEW=ON
                                -DBUILD_TESTING=OFF
                                -DWITH_EXAMPLES=OFF)

--- a/exporters/fluentd/cmake/opentelemetry-cpp.cmake
+++ b/exporters/fluentd/cmake/opentelemetry-cpp.cmake
@@ -13,11 +13,11 @@ function(build_opentelemetry)
   set(opentelemetry_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/opentelemetry-cpp")
   set(opentelemetry_cpp_targets opentelemetry_trace opentelemetry_logs http_client_curl )
   set(opentelemetry_CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-	                       -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-	                       -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-	 		       -DWITH_LOGS_PREVIEW=ON
-                               -DBUILD_TESTING=OFF
-                               -DWITH_EXAMPLES=OFF)
+            -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+            -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+	 		      -DWITH_LOGS_PREVIEW=ON
+            -DBUILD_TESTING=OFF
+            -DWITH_EXAMPLES=OFF)
 
   set(opentelemetry_libs
     ${opentelemetry_BINARY_DIR}/sdk/src/trace/libopentelemetry_trace.a

--- a/exporters/fluentd/cmake/opentelemetry-cpp.cmake
+++ b/exporters/fluentd/cmake/opentelemetry-cpp.cmake
@@ -13,11 +13,11 @@ function(build_opentelemetry)
   set(opentelemetry_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/opentelemetry-cpp")
   set(opentelemetry_cpp_targets opentelemetry_trace opentelemetry_logs http_client_curl )
   set(opentelemetry_CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-            -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-            -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-	 		      -DWITH_LOGS_PREVIEW=ON
-            -DBUILD_TESTING=OFF
-            -DWITH_EXAMPLES=OFF)
+          -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+          -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+	 		    -DWITH_LOGS_PREVIEW=ON
+          -DBUILD_TESTING=OFF
+          -DWITH_EXAMPLES=OFF)
 
   set(opentelemetry_libs
     ${opentelemetry_BINARY_DIR}/sdk/src/trace/libopentelemetry_trace.a


### PR DESCRIPTION
opentelemetry-cpp is built as an external project from within fluent exporter. In the case of cross-compilation build, cmake flags need to be explicitly propagated to the external project in order to get the platform-specific binaries generated. This PR adds this change.