### PR TITLE
Update Apr and Apr-Util to the recent versions

### DIFF
--- a/instrumentation/otel-webserver-module/Dockerfile
+++ b/instrumentation/otel-webserver-module/Dockerfile
@@ -205,12 +205,12 @@ RUN mkdir -p dependencies/googletest/1.10.0/ \
 
 #Installing Apache and apr source code
 RUN mkdir build-dependencies \
-    && wget --no-check-certificate https://archive.apache.org/dist/apr/apr-1.5.2.tar.gz \
-    && tar -xf apr-1.5.2.tar.gz \
-    && mv -f apr-1.5.2 build-dependencies \
-    && wget --no-check-certificate https://archive.apache.org/dist/apr/apr-util-1.5.4.tar.gz \
-    && tar -xf apr-util-1.5.4.tar.gz \
-    && mv -f apr-util-1.5.4 build-dependencies \
+    && wget --no-check-certificate https://archive.apache.org/dist/apr/apr-1.7.0.tar.gz \
+    && tar -xf apr-1.7.0.tar.gz \
+    && mv -f apr-1.7.0 build-dependencies \
+    && wget --no-check-certificate https://archive.apache.org/dist/apr/apr-util-1.6.1.tar.gz \
+    && tar -xf apr-util-1.6.1.tar.gz \
+    && mv -f apr-util-1.6.1 build-dependencies \
     && wget --no-check-certificate http://archive.apache.org/dist/httpd/httpd-2.2.31.tar.gz \
     && tar -xf httpd-2.2.31.tar.gz \
     && mv -f httpd-2.2.31 build-dependencies \
@@ -239,7 +239,7 @@ RUN cd /otel-webserver-module/build \
 # Remove unwanted files
 RUN rm -rf grpc && rm -rf autoconf-2.68 && rm -rf automake-1.16.3 && rm -rf cmake-3.20.0-linux-x86_64 \
     && rm -rf libtool-2.4.6 && rm -rf Python-2.7.8 \
-    && rm -f apr-1.5.2.tar.gz && rm -f apr-util-1.5.4.tar.gz \
+    && rm -f apr-1.7.0.tar.gz && rm -f apr-util-1.6.1.tar.gz \
     && rm -f httpd-2.2.31.tar.gz && rm -f httpd-2.4.23.tar.gz
 
 COPY entrypoint.sh /usr/local/bin/

--- a/instrumentation/otel-webserver-module/README.md
+++ b/instrumentation/otel-webserver-module/README.md
@@ -36,8 +36,8 @@ Monitoring individual modules is crucial to the instrumentation of Apache web se
 | Library                                        | Present Version |
 | ---------------------------------------------- | -----------     |
 | Httpd                                          | 2.4.23, 2.2.31          |
-| Apr                                            | 1.5.2           |
-| Apr-util                                       | 1.5.4           |
+| Apr                                            | 1.7.0           |
+| Apr-util                                       | 1.6.1           |
 
 ### Configuration
 | Configuration Directives                       |  Default Values |  Remarks                                   |

--- a/instrumentation/otel-webserver-module/build.gradle
+++ b/instrumentation/otel-webserver-module/build.gradle
@@ -49,7 +49,6 @@ project.ext {
     apache22Version = "2.2.31"
     apache24Version = "2.4.23"
 
-    boostDir = "${modDepDir}/boost/1.55.0"
     libraryStageDir = "${platBuildDir}/opentelemetry-webserver-sdk"
     apacheStageDir = "${libraryStageDir}/WebServerModule/Apache"
 
@@ -231,22 +230,22 @@ task bundleAprSources {
         }
 
         copy {
-            from "${buildDir}/apr-1.5.2"
+            from "${buildDir}/apr-1.7.0"
             into "${platBuildDir}/httpd-${apache22Version}/srclib/apr"
         }
 
         copy {
-            from "${buildDir}/apr-1.5.2"
+            from "${buildDir}/apr-1.7.0"
             into "${platBuildDir}/httpd-${apache24Version}/srclib/apr"
         }
 
         copy {
-            from "${buildDir}/apr-util-1.5.4"
+            from "${buildDir}/apr-util-1.6.1"
             into "${platBuildDir}/httpd-${apache22Version}/srclib/apr-util"
         }
 
         copy {
-            from "${buildDir}/apr-util-1.5.4"
+            from "${buildDir}/apr-util-1.6.1"
             into "${platBuildDir}/httpd-${apache24Version}/srclib/apr-util"
         }
     }

--- a/instrumentation/otel-webserver-module/install.sh
+++ b/instrumentation/otel-webserver-module/install.sh
@@ -1,4 +1,3 @@
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007
 cd /otel-webserver-module
 ./gradlew assembleApacheModule -PbuildType=debug
 


### PR DESCRIPTION
Apr and Apr-util source code are also used to generate the header files which are used for compilation. Updated the versions to be in sync with the versions used as library dependency.