### PR TITLE
upgrade fluentd exporter to use otel-cpp 1.3.0

### DIFF
--- a/exporters/fluentd/cmake/opentelemetry-cpp.cmake
+++ b/exporters/fluentd/cmake/opentelemetry-cpp.cmake
@@ -1,5 +1,5 @@
 if("${opentelemetry-cpp-tag}" STREQUAL "")
-    set(opentelemetry-cpp-tag "v1.1.1")
+    set(opentelemetry-cpp-tag "v1.3.0")
 endif()
 function(target_create _target _lib)
   add_library(${_target} STATIC IMPORTED)
@@ -11,7 +11,7 @@ endfunction()
 function(build_opentelemetry)
   set(opentelemetry_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry-cpp")
   set(opentelemetry_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/opentelemetry-cpp")
-  set(opentelemetry_cpp_targets opentelemetry_trace opentelemetry_logs http_client_curl )
+  set(opentelemetry_cpp_targets opentelemetry_trace opentelemetry_logs opentelemetry_http_client_curl )
   set(opentelemetry_CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON
           -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
           -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}

--- a/exporters/fluentd/example/log/foo_library/foo_library.cc
+++ b/exporters/fluentd/example/log/foo_library/foo_library.cc
@@ -10,7 +10,7 @@ namespace nostd = opentelemetry::nostd;
 namespace {
 nostd::shared_ptr<logs::Logger> get_logger() {
   auto provider = logs::Provider::GetLoggerProvider();
-  return provider->GetLogger("foo_library");
+  return provider->GetLogger("foo_library", "", "foo_library");
 }
 
 void f1() {

--- a/exporters/fluentd/example/log/main.cc
+++ b/exporters/fluentd/example/log/main.cc
@@ -19,16 +19,14 @@ void initLogger() {
   options.endpoint = "tcp://localhost:24222";
   auto exporter = std::unique_ptr<sdk_logs::LogExporter>(
       new opentelemetry::exporter::fluentd::logs::FluentdExporter(options));
-  auto processor = std::shared_ptr<sdk_logs::LogProcessor>(
+  auto processor = std::unique_ptr<sdk_logs::LogProcessor>(
       new sdk_logs::SimpleLogProcessor(std::move(exporter)));
 
   auto provider = std::shared_ptr<opentelemetry::logs::LoggerProvider>(
-      new opentelemetry::sdk::logs::LoggerProvider());
+      new opentelemetry::sdk::logs::LoggerProvider(std::move(processor)));
 
   auto pr =
       static_cast<opentelemetry::sdk::logs::LoggerProvider *>(provider.get());
-
-  pr->SetProcessor(processor);
 
   // Set the global logger provider
   opentelemetry::logs::Provider::SetLoggerProvider(provider);

--- a/exporters/fluentd/include/opentelemetry/exporters/fluentd/log/recordable.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/fluentd/log/recordable.h
@@ -43,13 +43,10 @@ public:
 
   /**
    * Set a resource for this log.
-   * @param name the name of the resource
-   * @param value the resource value
+   * @param Resource the resource to set
    */
-  void SetResource(
-      nostd::string_view key,
-      const opentelemetry::common::AttributeValue &value) noexcept override {
-  } // Not Supported
+  void SetResource(const opentelemetry::sdk::resource::Resource
+                       &resource) noexcept override {} // Not Supported
 
   /**
    * Set an attribute of a log.
@@ -87,6 +84,14 @@ public:
    */
   void SetTimestamp(
       opentelemetry::common::SystemTimestamp timestamp) noexcept override;
+
+  /**
+   * Set instrumentation_library for this log.
+   * @param instrumentation_library the instrumentation library to set
+   */
+  void SetInstrumentationLibrary(
+      const opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary
+          &instrumentation_library) noexcept override {} // Not Supported
 
   nlohmann::json &Log() { return json_; }
 


### PR DESCRIPTION
Upgrade fluentd exporter to move from otel-1.1.0 to otel-1.3.0. This needed fix for couple of breaking changes : 

- Use otel-cpp target `opentelemetry_http_client_curl`
- Logger support for Resources and Instrumentation Library.