### PR TITLE
fix(nginx): Fix segfault in GetTraceContext

### DIFF
--- a/instrumentation/nginx/src/otel_ngx_module.cpp
+++ b/instrumentation/nginx/src/otel_ngx_module.cpp
@@ -412,7 +412,7 @@ TraceContext* CreateTraceContext(ngx_http_request_t* req, ngx_http_variable_valu
   cleanup->handler = TraceContextCleanup;
 
   std::unordered_map<ngx_http_request_t*, TraceContext*>* map;
-  if (req->parent) {
+  if (req->parent && val->data) {
     // Subrequests will already have the map created so just retrieve it
     map = (std::unordered_map<ngx_http_request_t*, TraceContext*>*)val->data;
   } else {

--- a/instrumentation/nginx/test/backend/php/ignored.php
+++ b/instrumentation/nginx/test/backend/php/ignored.php
@@ -1,0 +1,9 @@
+<?php
+  $traceparent = $_SERVER["HTTP_TRACEPARENT"];
+  if (preg_match("/00-[0-9a-f]{32}-[0-9a-f]{16}-0[0-1]/", $traceparent ?? "")) {
+    echo("valid  traceparent");
+    throw new Exception("valid traceparent");
+  }
+
+  header("Content-Type: application/json");
+?>

--- a/instrumentation/nginx/test/conf/nginx.conf
+++ b/instrumentation/nginx/test/conf/nginx.conf
@@ -5,7 +5,7 @@ events {}
 http {
   opentelemetry_config /conf/otel-nginx.toml;
   opentelemetry_operation_name otel_test;
-  opentelemetry_ignore_paths .*\.js;
+  opentelemetry_ignore_paths ignored.php;
   access_log stderr;
   error_log stderr debug;
 

--- a/instrumentation/nginx/test/instrumentation/test/instrumentation_test.exs
+++ b/instrumentation/nginx/test/instrumentation/test/instrumentation_test.exs
@@ -398,7 +398,7 @@ defmodule InstrumentationTest do
 
   test "Accessing a excluded uri produces no span", %{trace_file: trace_file} do
     %HTTPoison.Response{status_code: status, body: body} =
-      HTTPoison.get!("#{@host}/files/file.js")
+      HTTPoison.get!("#{@host}/ignored.php")
 
     assert_raise RuntimeError, "timed out waiting for traces", fn ->
       read_traces(trace_file, 1)


### PR DESCRIPTION
We are seeing a segfault in `GetTraceContext(ngx_http_request_s*)` when some requests are not traced. This PR should fix it.