### PR TITLE
Https is ignored when configured by env var

### DIFF
--- a/instrumentation/nginx/src/agent_config.cpp
+++ b/instrumentation/nginx/src/agent_config.cpp
@@ -21,6 +21,7 @@ static bool SetupOtlpExporter(toml_table_t* table, ngx_log_t* log, OtelNgxAgentC
   auto endpoint_from_env = std::getenv(otel_exporter_otlp_endpoint_env);
 
   if (endpoint_from_env) {
+    config->exporter.use_ssl_credentials = std::string(endpoint_from_env).find("https://") != std::string::npos;
     config->exporter.endpoint = endpoint_from_env;
     return true;
   }


### PR DESCRIPTION
Basically if you configure the endpoint via environment variable, it will always to try communicate via insecure. Because use_ssl_credentials is used in the grpc exporter, but we never set it. And it can be configured via conf file, but only if you don't use the env variable.