### PR TITLE
Added CI for otel-webserver-module

### DIFF
--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -24,6 +24,9 @@ jobs:
           echo "Hello world"
           cd instrumentation/otel-webserver-module
           docker-compose --profile ubuntu20.04 build
-
+      - name: test
+        run: |
+          docker run -idt --name apache_ubuntu_container apache_ubuntu /bin/bash
+          docker exec apache_ubuntu_container bash -c 'cd /otel-webserver-module; ./gradlew runUnitTest -PtargetSystem=ubuntu'
 
 

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -35,12 +35,20 @@ jobs:
         run: |
           echo "Hello world"
           cd instrumentation/otel-webserver-module
-          docker buildx build -t apache_ubuntu -f docker/ubuntu20.04/Dockerfile .
+          docker buildx build -t apache_ubuntu -f docker/ubuntu20.04/Dockerfile \
+            --cache-from type=local,src=/tmp/buildx-cache/apache_ubuntu \
+            --cache-to type=local,dest=/tmp/buildx-cache/apache_ubuntu-new \
+            --load .
           #docker-compose --profile ubuntu20.04 build
       - name: test
         run: |
           docker run -idt --name apache_ubuntu_container apache_ubuntu /bin/bash
-          docker exec apache_ubuntu_container bash -c 'cd /otel-webserver-module; ./gradlew runUnitTest -DtargetSystem=ubuntu'
+          docker exec apache_ubuntu_container bash -c \
+            'cd /otel-webserver-module; ./gradlew runUnitTest -DtargetSystem=ubuntu'
+      - name: update cache
+        run: |
+          rm -rf /tmp/buildx-cache/apache_ubuntu
+          mv /tmp/buildx-cache/apache_ubuntu-new /tmp/buildx-cache/apache_ubuntu
 #  webserver-build-test-centos7:
 #    name: apache-centos7
 #    runs-on: ubuntu-20.04

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           docker run -idt --name apache_ubuntu_container apache_ubuntu /bin/bash
           cd instrumentation/otel-webserver-module
+          docker exec apache_ubuntu_container bash -c \
+            'cd /otel-webserver-module; rm -rf *;'
           docker cp /. apache_ubuntu_container:/otel-webserver-module/
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule -DtargetSystem=ubuntu'
@@ -84,6 +86,8 @@ jobs:
         run: |
           docker run -idt --name apache_centos7_container apache_centos7 /bin/bash
           cd instrumentation/otel-webserver-module
+          docker exec apache_centos7_container bash -c \
+            'cd /otel-webserver-module; rm -rf *;'
           docker cp /. apache_centos7_container:/otel-webserver-module/
           docker exec apache_centos7_container bash -c \
             'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule'

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -39,7 +39,6 @@ jobs:
             --cache-from type=local,src=/tmp/buildx-cache/apache_ubuntu \
             --cache-to type=local,dest=/tmp/buildx-cache/apache_ubuntu-new \
             --load .
-          #docker-compose --profile ubuntu20.04 build
       - name: test
         run: |
           docker run -idt --name apache_ubuntu_container apache_ubuntu /bin/bash
@@ -49,6 +48,18 @@ jobs:
         run: |
           rm -rf /tmp/buildx-cache/apache_ubuntu
           mv /tmp/buildx-cache/apache_ubuntu-new /tmp/buildx-cache/apache_ubuntu
+      - name: copy artifacts
+        id: artifacts
+        run: |
+          cd instrumentation/otel-webserver-module
+          mkdir -p /tmp/apache_ubuntu/
+          docker cp apache_ubuntu_container:/otel-webserver-module/build/opentelemetry-webserver-sdk-x64-linux.tgz \
+            /tmp/apache_ubuntu/
+      - name: upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: opentelemetry-webserver-sdk-x64-linux.tgz
+          path: /tmp/apache_ubuntu/otel_ngx/opentelemetry-webserver-sdk-x64-linux.tgz
 #  webserver-build-test-centos7:
 #    name: apache-centos7
 #    runs-on: ubuntu-20.04

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -15,13 +15,13 @@ on:
 jobs:
   webserver-build-test:
     name: webserver
-    runs-on: macos-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout otel webserver
         uses: actions/checkout@v3
       - name: setup
         run: |
-          brew install docker
+          echo "Hello world"
           docker -v
-          open -a docker
+
 

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -27,6 +27,6 @@ jobs:
       - name: test
         run: |
           docker run -idt --name apache_ubuntu_container apache_ubuntu /bin/bash
-          docker exec apache_ubuntu_container bash -c 'cd /otel-webserver-module; ./gradlew runUnitTest -PtargetSystem=ubuntu'
+          docker exec apache_ubuntu_container bash -c 'cd /otel-webserver-module; ./gradlew runUnitTest -DtargetSystem=ubuntu'
 
 

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -31,15 +31,21 @@ jobs:
           key: apache-ubuntu-20.04-${{ github.sha }}
           restore-keys: |
             apache-ubuntu-20.04
-      - name: build
+      - name: setup docker image
         run: |
-          echo "Hello world"
           cd instrumentation/otel-webserver-module
           docker buildx build -t apache_ubuntu -f docker/ubuntu20.04/Dockerfile \
             --cache-from type=local,src=/tmp/buildx-cache/apache_ubuntu \
             --cache-to type=local,dest=/tmp/buildx-cache/apache_ubuntu-new \
             --load .
-      - name: test
+      - name: build
+        run: |
+          docker run -idt --name apache_ubuntu_container apache_ubuntu /bin/bash
+          cd instrumentation/otel-webserver-module
+          docker cp /. apache_ubuntu_container:/otel-webserver-module/
+          docker exec apache_ubuntu_container bash -c \
+            'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule -DtargetSystem=ubuntu'
+      - name: unit test
         run: |
           docker run -idt --name apache_ubuntu_container apache_ubuntu /bin/bash
           docker exec apache_ubuntu_container bash -c \
@@ -48,29 +54,56 @@ jobs:
         run: |
           rm -rf /tmp/buildx-cache/apache_ubuntu
           mv /tmp/buildx-cache/apache_ubuntu-new /tmp/buildx-cache/apache_ubuntu
+
+  webserver-build-test-centos7:
+    name: apache-centos7
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout otel webserver
+        uses: actions/checkout@v3
+      - name: setup buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          install: true
+      - name: cache docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/buildx-cache/
+          key: apache-centos7-${{ github.sha }}
+          restore-keys: |
+            apache-centos7
+      - name: setup docker image
+        run: |
+          cd instrumentation/otel-webserver-module
+          docker buildx build -t apache_centos7 -f docker/centos7/Dockerfile \
+            --cache-from type=local,src=/tmp/buildx-cache/apache_centos7 \
+            --cache-to type=local,dest=/tmp/buildx-cache/apache_centos7-new \
+            --load .
+      - name: build
+        run: |
+          docker run -idt --name apache_centos7_container apache_centos7 /bin/bash
+          cd instrumentation/otel-webserver-module
+          docker cp /. apache_centos7_container:/otel-webserver-module/
+          docker exec apache_centos7_container bash -c \
+            'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule'
+      - name: unit test
+        run: |
+          docker exec apache_centos7_container bash -c \
+            'cd /otel-webserver-module; ./gradlew runUnitTest'
+      - name: update cache
+        run: |
+          rm -rf /tmp/buildx-cache/apache_centos7
+          mv /tmp/buildx-cache/apache_centos7-new /tmp/buildx-cache/apache_centos7
       - name: copy artifacts
         id: artifacts
         run: |
           cd instrumentation/otel-webserver-module
-          mkdir -p /tmp/apache_ubuntu/
-          docker cp apache_ubuntu_container:/otel-webserver-module/build/opentelemetry-webserver-sdk-x64-linux.tgz \
-            /tmp/apache_ubuntu/
+          mkdir -p /tmp/apache_centos7/
+          docker cp apache_centos7_container:/otel-webserver-module/build/opentelemetry-webserver-sdk-x64-linux.tgz \
+            /tmp/apache_centos7/
       - name: upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: opentelemetry-webserver-sdk-x64-linux.tgz
-          path: /tmp/apache_ubuntu/opentelemetry-webserver-sdk-x64-linux.tgz
-#  webserver-build-test-centos7:
-#    name: apache-centos7
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: checkout otel webserver
-#        uses: actions/checkout@v3
-#      - name: build
-#        run: |
-#          cd instrumentation/otel-webserver-module
-#          docker-compose --profile centos7 build
-#      - name: test
-#        run: |
-#          docker run -idt --name apache_centos7_container apache_centos7 /bin/bash
-#          docker exec apache_centos7_container bash -c 'cd /otel-webserver-module; ./gradlew runUnitTest'
+          path: /tmp/apache_centos7/opentelemetry-webserver-sdk-x64-linux.tgz

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -45,8 +45,11 @@ jobs:
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf *;'
           docker cp . $(docker inspect --format="{{.Id}}" apache_ubuntu_container):/otel-webserver-module/
-          docker exec apache_ubuntu_container bash -c \
-            'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule -DtargetSystem=ubuntu'
+          docker exec apache_ubuntu_container bash -c              \
+            'cd /otel-webserver-module; rm -rf build;              \
+            cp -r /dependencies /otel-webserver-module/;           \
+            cp -r /build-dependencies /otel-webserver-module/;     \
+            ./gradlew assembleApacheModule -DtargetSystem=ubuntu'
       - name: unit test
         run: |
           docker run -idt --name apache_ubuntu_container apache_ubuntu /bin/bash

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -7,7 +7,7 @@ on:
       - 'instrumentation/otel-webserver-module/**'
       - '.github/workflows/webserver.yml'
   pull_request:
-    branches: [ ci-test ]
+    branches: [ main ]
     paths:
       - 'instrumentation/otel-webserver-module/**'
       - '.github/workflows/webserver.yml'

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           cd instrumentation/otel-webserver-module
           docker buildx build -t apache_centos7 -f docker/centos7/Dockerfile \
-            --cache-from type=local,src=/tmp/buildx-cache/apache_centos7-new \
+            --cache-from type=local,src=/tmp/buildx-cache/apache_centos7 \
             --cache-to type=local,dest=/tmp/buildx-cache/apache_centos7-new \
             --load .
       - name: build

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -44,8 +44,7 @@ jobs:
           cd instrumentation/otel-webserver-module
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf *;'
-
-          docker cp . ${{ docker inspect --format="{{.Id}}" apache_ubuntu_container }}:/otel-webserver-module/
+          docker cp . ${{ docker inspect --format={{.Id}} apache_ubuntu_container }}:/otel-webserver-module/
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule -DtargetSystem=ubuntu'
       - name: unit test

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -44,8 +44,7 @@ jobs:
           cd instrumentation/otel-webserver-module
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf *;'
-          echo "CONTAINER_NAME=$(docker inspect --format="{{.Id}}" apache_ubuntu_container)" >> $GITHUB_ENV
-          docker cp . ${{ env.CONTAINER_NAME }}:/otel-webserver-module/
+          docker cp . $(docker inspect --format="{{.Id}}" apache_ubuntu_container):/otel-webserver-module/
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule -DtargetSystem=ubuntu'
       - name: unit test

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: opentelemetry-webserver-sdk-x64-linux.tgz
-          path: /tmp/apache_ubuntu/otel_ngx/opentelemetry-webserver-sdk-x64-linux.tgz
+          path: /tmp/apache_ubuntu/opentelemetry-webserver-sdk-x64-linux.tgz
 #  webserver-build-test-centos7:
 #    name: apache-centos7
 #    runs-on: ubuntu-20.04

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           cd instrumentation/otel-webserver-module
           docker buildx build -t apache_centos7 -f docker/centos7/Dockerfile \
-            --cache-from type=local,src=/tmp/buildx-cache/apache_centos7 \
+            --cache-from type=local,src=/tmp/buildx-cache/apache_centos7-new \
             --cache-to type=local,dest=/tmp/buildx-cache/apache_centos7-new \
             --load .
       - name: build
@@ -90,7 +90,7 @@ jobs:
           cd instrumentation/otel-webserver-module
           docker exec apache_centos7_container bash -c \
             'cd /otel-webserver-module; rm -rf *;'
-          docker cp . $(docker inspect --format="{{.Id}}" apache_ubuntu_container):/otel-webserver-module/
+          docker cp . $(docker inspect --format="{{.Id}}" apache_centos7_container):/otel-webserver-module/
           docker exec apache_centos7_container bash -c \
             'cd /otel-webserver-module; rm -rf build; \
             cp -r /dependencies /otel-webserver-module/;           \

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -44,7 +44,7 @@ jobs:
           cd instrumentation/otel-webserver-module
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf *;'
-          echo "CONTAINER_NAME=$(sudo docker ps -aqf "name=^apache_ubuntu_container$")" >> $GITHUB_ENV
+          echo "CONTAINER_NAME=$(docker inspect --format="{{.Id}}" apache_ubuntu_container)" >> $GITHUB_ENV
           docker cp . ${{ env.CONTAINER_NAME }}:/otel-webserver-module/
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule -DtargetSystem=ubuntu'

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -2,7 +2,7 @@ name: webserver instrumentation CI
 
 on:
   push:
-    branches: "*"
+    branches: [ main ]
     paths:
       - 'instrumentation/otel-webserver-module/**'
       - '.github/workflows/webserver.yml'

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -44,7 +44,7 @@ jobs:
           cd instrumentation/otel-webserver-module
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf *;'
-          echo "CONTAINER_NAME=$(docker ps -aqf "name=^apache_ubuntu_container$")" >> $GITHUB_ENV
+          echo "CONTAINER_NAME=$(sudo docker ps -aqf "name=^apache_ubuntu_container$")" >> $GITHUB_ENV
           docker cp . ${{ env.CONTAINER_NAME }}:/otel-webserver-module/
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule -DtargetSystem=ubuntu'

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -19,26 +19,39 @@ jobs:
     steps:
       - name: checkout otel webserver
         uses: actions/checkout@v3
+      - name: setup buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          install: true
+      - name: cache docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/buildx-cache/
+          key: apache-ubuntu-20.04-${{ github.sha }}
+          restore-keys: |
+            apache-ubuntu-20.04
       - name: build
         run: |
           echo "Hello world"
           cd instrumentation/otel-webserver-module
-          docker-compose --profile ubuntu20.04 build
+          docker buildx build -t apache_ubuntu -f docker/ubuntu20.04/Dockerfile .
+          #docker-compose --profile ubuntu20.04 build
       - name: test
         run: |
           docker run -idt --name apache_ubuntu_container apache_ubuntu /bin/bash
           docker exec apache_ubuntu_container bash -c 'cd /otel-webserver-module; ./gradlew runUnitTest -DtargetSystem=ubuntu'
-  webserver-build-test-centos7:
-    name: apache-centos7
-    runs-on: ubuntu-20.04
-    steps:
-      - name: checkout otel webserver
-        uses: actions/checkout@v3
-      - name: build
-        run: |
-          cd instrumentation/otel-webserver-module
-          docker-compose --profile centos7 build
-      - name: test
-        run: |
-          docker run -idt --name apache_centos7_container apache_centos7 /bin/bash
-          docker exec apache_centos7_container bash -c 'cd /otel-webserver-module; ./gradlew runUnitTest'
+#  webserver-build-test-centos7:
+#    name: apache-centos7
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: checkout otel webserver
+#        uses: actions/checkout@v3
+#      - name: build
+#        run: |
+#          cd instrumentation/otel-webserver-module
+#          docker-compose --profile centos7 build
+#      - name: test
+#        run: |
+#          docker run -idt --name apache_centos7_container apache_centos7 /bin/bash
+#          docker exec apache_centos7_container bash -c 'cd /otel-webserver-module; ./gradlew runUnitTest'

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -20,5 +20,5 @@ jobs:
       - name: checkout otel webserver
         uses: actions/checkout@v3
       - name: setup
-        run: echo "Hello World"
+        run: brew install docker
 

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -22,7 +22,8 @@ jobs:
       - name: setup
         run: |
           echo "Hello world"
-          docker -v
-          docker run hello-world
+          cd instrumentation/otel-webserver-module
+          docker-compose --profile ubuntu20.04 build
+
 
 

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -13,13 +13,13 @@ on:
       - '.github/workflows/webserver.yml'
 
 jobs:
-  webserver-build-test:
-    name: webserver
+  webserver-build-test-ubuntu:
+    name: apache-ubuntu
     runs-on: ubuntu-20.04
     steps:
       - name: checkout otel webserver
         uses: actions/checkout@v3
-      - name: setup
+      - name: build
         run: |
           echo "Hello world"
           cd instrumentation/otel-webserver-module
@@ -28,5 +28,17 @@ jobs:
         run: |
           docker run -idt --name apache_ubuntu_container apache_ubuntu /bin/bash
           docker exec apache_ubuntu_container bash -c 'cd /otel-webserver-module; ./gradlew runUnitTest -DtargetSystem=ubuntu'
-
-
+  webserver-build-test-centos7:
+    name: apache-centos7
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout otel webserver
+        uses: actions/checkout@v3
+      - name: build
+        run: |
+          cd instrumentation/otel-webserver-module
+          docker-compose --profile centos7 build
+      - name: test
+        run: |
+          docker run -idt --name apache_centos7_container apache_centos7 /bin/bash
+          docker exec apache_centos7_container bash -c 'cd /otel-webserver-module; ./gradlew runUnitTest'

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -20,5 +20,8 @@ jobs:
       - name: checkout otel webserver
         uses: actions/checkout@v3
       - name: setup
-        run: brew install docker
+        run: |
+          brew install docker
+          docker -v
+          open -a Docker
 

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -59,57 +59,60 @@ jobs:
           rm -rf /tmp/buildx-cache/apache_ubuntu
           mv /tmp/buildx-cache/apache_ubuntu-new /tmp/buildx-cache/apache_ubuntu
 
-  # webserver-build-test-centos7:
-  #   name: apache-centos7
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: checkout otel webserver
-  #       uses: actions/checkout@v3
-  #     - name: setup buildx
-  #       id: buildx
-  #       uses: docker/setup-buildx-action@master
-  #       with:
-  #         install: true
-  #     - name: cache docker layers
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: /tmp/buildx-cache/
-  #         key: apache-centos7-${{ github.sha }}
-  #         restore-keys: |
-  #           apache-centos7
-  #     - name: setup docker image
-  #       run: |
-  #         cd instrumentation/otel-webserver-module
-  #         docker buildx build -t apache_centos7 -f docker/centos7/Dockerfile \
-  #           --cache-from type=local,src=/tmp/buildx-cache/apache_centos7 \
-  #           --cache-to type=local,dest=/tmp/buildx-cache/apache_centos7-new \
-  #           --load .
-  #     - name: build
-  #       run: |
-  #         docker run -idt --name apache_centos7_container apache_centos7 /bin/bash
-  #         cd instrumentation/otel-webserver-module
-  #         docker exec apache_centos7_container bash -c \
-  #           'cd /otel-webserver-module; rm -rf *;'
-  #         docker cp /. apache_centos7_container:/otel-webserver-module/
-  #         docker exec apache_centos7_container bash -c \
-  #           'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule'
-  #     - name: unit test
-  #       run: |
-  #         docker exec apache_centos7_container bash -c \
-  #           'cd /otel-webserver-module; ./gradlew runUnitTest'
-  #     - name: update cache
-  #       run: |
-  #         rm -rf /tmp/buildx-cache/apache_centos7
-  #         mv /tmp/buildx-cache/apache_centos7-new /tmp/buildx-cache/apache_centos7
-  #     - name: copy artifacts
-  #       id: artifacts
-  #       run: |
-  #         cd instrumentation/otel-webserver-module
-  #         mkdir -p /tmp/apache_centos7/
-  #         docker cp apache_centos7_container:/otel-webserver-module/build/opentelemetry-webserver-sdk-x64-linux.tgz \
-  #           /tmp/apache_centos7/
-  #     - name: upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: opentelemetry-webserver-sdk-x64-linux.tgz
-  #         path: /tmp/apache_centos7/opentelemetry-webserver-sdk-x64-linux.tgz
+  webserver-build-test-centos7:
+    name: apache-centos7
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout otel webserver
+        uses: actions/checkout@v3
+      - name: setup buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          install: true
+      - name: cache docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/buildx-cache/
+          key: apache-centos7-${{ github.sha }}
+          restore-keys: |
+            apache-centos7
+      - name: setup docker image
+        run: |
+          cd instrumentation/otel-webserver-module
+          docker buildx build -t apache_centos7 -f docker/centos7/Dockerfile \
+            --cache-from type=local,src=/tmp/buildx-cache/apache_centos7 \
+            --cache-to type=local,dest=/tmp/buildx-cache/apache_centos7-new \
+            --load .
+      - name: build
+        run: |
+          docker run -idt --name apache_centos7_container apache_centos7 /bin/bash
+          cd instrumentation/otel-webserver-module
+          docker exec apache_centos7_container bash -c \
+            'cd /otel-webserver-module; rm -rf *;'
+          docker cp . $(docker inspect --format="{{.Id}}" apache_ubuntu_container):/otel-webserver-module/
+          docker exec apache_centos7_container bash -c \
+            'cd /otel-webserver-module; rm -rf build; \
+            cp -r /dependencies /otel-webserver-module/;           \
+            cp -r /build-dependencies /otel-webserver-module/;     \
+            ./gradlew assembleApacheModule'
+      - name: unit test
+        run: |
+          docker exec apache_centos7_container bash -c \
+            'cd /otel-webserver-module; ./gradlew runUnitTest'
+      - name: update cache
+        run: |
+          rm -rf /tmp/buildx-cache/apache_centos7
+          mv /tmp/buildx-cache/apache_centos7-new /tmp/buildx-cache/apache_centos7
+      - name: copy artifacts
+        id: artifacts
+        run: |
+          cd instrumentation/otel-webserver-module
+          mkdir -p /tmp/apache_centos7/
+          docker cp apache_centos7_container:/otel-webserver-module/build/opentelemetry-webserver-sdk-x64-linux.tgz \
+            /tmp/apache_centos7/
+      - name: upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: opentelemetry-webserver-sdk-x64-linux.tgz
+          path: /tmp/apache_centos7/opentelemetry-webserver-sdk-x64-linux.tgz

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -1,0 +1,24 @@
+name: webserver instrumentation CI
+
+on:
+  push:
+    branches: "*"
+    paths:
+      - 'instrumentation/otel-webserver-module/**'
+      - '.github/workflows/webserver.yml'
+  pull_request:
+    branches: [ ci-test ]
+    paths:
+      - 'instrumentation/otel-webserver-module/**'
+      - '.github/workflows/webserver.yml'
+
+jobs:
+  webserver-build-test:
+    name: webserver
+    runs-on: macos-latest
+    steps:
+      - name: checkout otel webserver
+        uses: actions/checkout@v3
+      - name: setup
+        run: echo "Hello World"
+

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -23,5 +23,5 @@ jobs:
         run: |
           brew install docker
           docker -v
-          open -a Docker
+          open -a docker
 

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -44,7 +44,8 @@ jobs:
           cd instrumentation/otel-webserver-module
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf *;'
-          docker cp /. apache_ubuntu_container:/otel-webserver-module/
+
+          docker cp . ${{ docker inspect --format="{{.Id}}" apache_ubuntu_container }}:/otel-webserver-module/
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule -DtargetSystem=ubuntu'
       - name: unit test
@@ -57,57 +58,57 @@ jobs:
           rm -rf /tmp/buildx-cache/apache_ubuntu
           mv /tmp/buildx-cache/apache_ubuntu-new /tmp/buildx-cache/apache_ubuntu
 
-  webserver-build-test-centos7:
-    name: apache-centos7
-    runs-on: ubuntu-20.04
-    steps:
-      - name: checkout otel webserver
-        uses: actions/checkout@v3
-      - name: setup buildx
-        id: buildx
-        uses: docker/setup-buildx-action@master
-        with:
-          install: true
-      - name: cache docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/buildx-cache/
-          key: apache-centos7-${{ github.sha }}
-          restore-keys: |
-            apache-centos7
-      - name: setup docker image
-        run: |
-          cd instrumentation/otel-webserver-module
-          docker buildx build -t apache_centos7 -f docker/centos7/Dockerfile \
-            --cache-from type=local,src=/tmp/buildx-cache/apache_centos7 \
-            --cache-to type=local,dest=/tmp/buildx-cache/apache_centos7-new \
-            --load .
-      - name: build
-        run: |
-          docker run -idt --name apache_centos7_container apache_centos7 /bin/bash
-          cd instrumentation/otel-webserver-module
-          docker exec apache_centos7_container bash -c \
-            'cd /otel-webserver-module; rm -rf *;'
-          docker cp /. apache_centos7_container:/otel-webserver-module/
-          docker exec apache_centos7_container bash -c \
-            'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule'
-      - name: unit test
-        run: |
-          docker exec apache_centos7_container bash -c \
-            'cd /otel-webserver-module; ./gradlew runUnitTest'
-      - name: update cache
-        run: |
-          rm -rf /tmp/buildx-cache/apache_centos7
-          mv /tmp/buildx-cache/apache_centos7-new /tmp/buildx-cache/apache_centos7
-      - name: copy artifacts
-        id: artifacts
-        run: |
-          cd instrumentation/otel-webserver-module
-          mkdir -p /tmp/apache_centos7/
-          docker cp apache_centos7_container:/otel-webserver-module/build/opentelemetry-webserver-sdk-x64-linux.tgz \
-            /tmp/apache_centos7/
-      - name: upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: opentelemetry-webserver-sdk-x64-linux.tgz
-          path: /tmp/apache_centos7/opentelemetry-webserver-sdk-x64-linux.tgz
+  # webserver-build-test-centos7:
+  #   name: apache-centos7
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: checkout otel webserver
+  #       uses: actions/checkout@v3
+  #     - name: setup buildx
+  #       id: buildx
+  #       uses: docker/setup-buildx-action@master
+  #       with:
+  #         install: true
+  #     - name: cache docker layers
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: /tmp/buildx-cache/
+  #         key: apache-centos7-${{ github.sha }}
+  #         restore-keys: |
+  #           apache-centos7
+  #     - name: setup docker image
+  #       run: |
+  #         cd instrumentation/otel-webserver-module
+  #         docker buildx build -t apache_centos7 -f docker/centos7/Dockerfile \
+  #           --cache-from type=local,src=/tmp/buildx-cache/apache_centos7 \
+  #           --cache-to type=local,dest=/tmp/buildx-cache/apache_centos7-new \
+  #           --load .
+  #     - name: build
+  #       run: |
+  #         docker run -idt --name apache_centos7_container apache_centos7 /bin/bash
+  #         cd instrumentation/otel-webserver-module
+  #         docker exec apache_centos7_container bash -c \
+  #           'cd /otel-webserver-module; rm -rf *;'
+  #         docker cp /. apache_centos7_container:/otel-webserver-module/
+  #         docker exec apache_centos7_container bash -c \
+  #           'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule'
+  #     - name: unit test
+  #       run: |
+  #         docker exec apache_centos7_container bash -c \
+  #           'cd /otel-webserver-module; ./gradlew runUnitTest'
+  #     - name: update cache
+  #       run: |
+  #         rm -rf /tmp/buildx-cache/apache_centos7
+  #         mv /tmp/buildx-cache/apache_centos7-new /tmp/buildx-cache/apache_centos7
+  #     - name: copy artifacts
+  #       id: artifacts
+  #       run: |
+  #         cd instrumentation/otel-webserver-module
+  #         mkdir -p /tmp/apache_centos7/
+  #         docker cp apache_centos7_container:/otel-webserver-module/build/opentelemetry-webserver-sdk-x64-linux.tgz \
+  #           /tmp/apache_centos7/
+  #     - name: upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: opentelemetry-webserver-sdk-x64-linux.tgz
+  #         path: /tmp/apache_centos7/opentelemetry-webserver-sdk-x64-linux.tgz

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -23,5 +23,6 @@ jobs:
         run: |
           echo "Hello world"
           docker -v
+          docker run hello-world
 
 

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -44,7 +44,8 @@ jobs:
           cd instrumentation/otel-webserver-module
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf *;'
-          docker cp . ${{ docker inspect --format={{.Id}} apache_ubuntu_container }}:/otel-webserver-module/
+          echo "CONTAINER_NAME=$(docker ps -aqf "name=^apache_ubuntu_container$")" >> $GITHUB_ENV
+          docker cp . ${{ env.CONTAINER_NAME }}:/otel-webserver-module/
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; rm -rf build; ./gradlew assembleApacheModule -DtargetSystem=ubuntu'
       - name: unit test

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -52,7 +52,6 @@ jobs:
             ./gradlew assembleApacheModule -DtargetSystem=ubuntu'
       - name: unit test
         run: |
-          docker run -idt --name apache_ubuntu_container apache_ubuntu /bin/bash
           docker exec apache_ubuntu_container bash -c \
             'cd /otel-webserver-module; ./gradlew runUnitTest -DtargetSystem=ubuntu'
       - name: update cache

--- a/.github/workflows/webserver.yml
+++ b/.github/workflows/webserver.yml
@@ -116,3 +116,50 @@ jobs:
         with:
           name: opentelemetry-webserver-sdk-x64-linux.tgz
           path: /tmp/apache_centos7/opentelemetry-webserver-sdk-x64-linux.tgz
+
+  webserver-build-test-centos6:
+    name: apache-centos6
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout otel webserver
+        uses: actions/checkout@v3
+      - name: setup buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          install: true
+      - name: cache docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/buildx-cache/
+          key: apache-centos6-${{ github.sha }}
+          restore-keys: |
+            apache-centos6
+      - name: setup docker image
+        run: |
+          cd instrumentation/otel-webserver-module
+          docker buildx build -t apache_centos6 -f Dockerfile \
+            --cache-from type=local,src=/tmp/buildx-cache/apache_centos6 \
+            --cache-to type=local,dest=/tmp/buildx-cache/apache_centos6-new \
+            --load .
+      - name: build
+        run: |
+          docker run -idt --name apache_centos6_container apache_centos6 /bin/bash
+          cd instrumentation/otel-webserver-module
+          docker exec apache_centos6_container bash -c \
+            'cd /otel-webserver-module; rm -rf *;'
+          docker cp . $(docker inspect --format="{{.Id}}" apache_centos6_container):/otel-webserver-module/
+          docker exec apache_centos6_container bash -c \
+            'cd /otel-webserver-module; rm -rf build; \
+            cp -r /dependencies /otel-webserver-module/;           \
+            cp -r /build-dependencies /otel-webserver-module/;     \
+            ./gradlew assembleApacheModule'
+      - name: unit test
+        run: |
+          docker exec apache_centos6_container bash -c \
+            'cd /otel-webserver-module; ./gradlew runUnitTest'
+      - name: update cache
+        run: |
+          rm -rf /tmp/buildx-cache/apache_centos6
+          mv /tmp/buildx-cache/apache_centos6-new /tmp/buildx-cache/apache_centos6
+


### PR DESCRIPTION
This PR adds the following changes:
1. Builds and run unit test for centos7 and ubuntu20.04 for every push and PR on main branch.
2. Publish the artifacts generated from centos7 