### PR TITLE
Address spec compliance issue (SetName method is deprecated and removed)

### DIFF
--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -14,20 +14,28 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-project(opentelemetry-fluentd)
-
+# MAIN_PROJECT CHECK
+## determine if fluentd exporter is built as a subproject (using add_subdirectory) or if it is the main project
+##
+set(MAIN_PROJECT OFF)
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  project(opentelemetry-fluentd)
+  set(MAIN_PROJECT ON)
+endif()
 add_definitions(-DHAVE_CONSOLE_LOG)
 add_definitions(-DENABLE_LOGS_PREVIEW)
 
-find_package(opentelemetry-cpp QUIET)
-if(opentelemetry_cpp_FOUND)
-  message("Using external opentelemetry-cpp")
-else()
-  include(cmake/opentelemetry-cpp.cmake)
-  build_opentelemetry()
-  set(OPENTELEMETRY_CPP_INCLUDE_DIRS "")
-  set(OPENTELEMETRY_CPP_LIBRARIES "opentelemetry::libopentelemetry")
-  message("\nopentelemetry-cpp package was not found. Cloned from github")
+if (MAIN_PROJECT)
+  find_package(opentelemetry-cpp QUIET)
+  if(opentelemetry_cpp_FOUND)
+    message("Using external opentelemetry-cpp")
+  else()
+    include(cmake/opentelemetry-cpp.cmake)
+    build_opentelemetry()
+    set(OPENTELEMETRY_CPP_INCLUDE_DIRS "")
+    set(OPENTELEMETRY_CPP_LIBRARIES "opentelemetry::libopentelemetry")
+    message("\nopentelemetry-cpp package was not found. Cloned from github")
+  endif()
 endif()
 
 find_package(nlohmann_json QUIET)
@@ -151,36 +159,38 @@ if(BUILD_TESTING)
     TEST_LIST fluentd_recordable_logs_test)
 endif() # BUILD_TESTING
 
-# config file for find_packages(opentelemetry-cpp-fluentd CONFIG)
-include(GNUInstallDirs)
-include(CMakePackageConfigHelpers)
+if (MAIN_PROJECT)
+  # config file for find_packages(opentelemetry-cpp-fluentd CONFIG)
+  include(GNUInstallDirs)
+  include(CMakePackageConfigHelpers)
 
-set(OPENTELEMETRY_CPP_FLUENTD_VERSION "1.1.1")
-set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
-configure_package_config_file(
-  "${CMAKE_CURRENT_LIST_DIR}/cmake/opentelemetry-cpp-fluentd-config.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
-  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
-  # PATH_VARS OPENTELEMETRY_CPP_FLUENTD_VERSION PROJECT_NAME INCLUDE_INSTALL_DIR
-  # CMAKE_INSTALL_LIBDIR
-  PATH_VARS PROJECT_NAME INCLUDE_INSTALL_DIR CMAKE_INSTALL_LIBDIR
-  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
-
-# Write version file for find_packages(opentelemetry-cpp-fluentd CONFIG)
-write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config-version.cmake"
-  VERSION ${OPENTELEMETRY_CPP_FLUENTD_VERSION}
-  COMPATIBILITY ExactVersion)
-
-install(
-  FILES
+  set(OPENTELEMETRY_CPP_FLUENTD_VERSION "1.1.1")
+  set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
+  configure_package_config_file(
+    "${CMAKE_CURRENT_LIST_DIR}/cmake/opentelemetry-cpp-fluentd-config.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config-version.cmake"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    # PATH_VARS OPENTELEMETRY_CPP_FLUENTD_VERSION PROJECT_NAME INCLUDE_INSTALL_DIR
+    # CMAKE_INSTALL_LIBDIR
+    PATH_VARS PROJECT_NAME INCLUDE_INSTALL_DIR CMAKE_INSTALL_LIBDIR
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO)
 
-# Export all components
-export(
-  EXPORT "${PROJECT_NAME}-target"
-  NAMESPACE "${PROJECT_NAME}::"
-  FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-target.cmake"
-)
+  # Write version file for find_packages(opentelemetry-cpp-fluentd CONFIG)
+  write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config-version.cmake"
+    VERSION ${OPENTELEMETRY_CPP_FLUENTD_VERSION}
+    COMPATIBILITY ExactVersion)
+
+  install(
+    FILES
+      "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
+      "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+  # Export all components
+  export(
+    EXPORT "${PROJECT_NAME}-target"
+    NAMESPACE "${PROJECT_NAME}::"
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-target.cmake"
+  )
+endif()

--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -164,7 +164,7 @@ if (MAIN_PROJECT)
   include(GNUInstallDirs)
   include(CMakePackageConfigHelpers)
 
-  set(OPENTELEMETRY_CPP_FLUENTD_VERSION "1.1.1")
+  set(OPENTELEMETRY_CPP_FLUENTD_VERSION "1.1.2")
   set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
   configure_package_config_file(
     "${CMAKE_CURRENT_LIST_DIR}/cmake/opentelemetry-cpp-fluentd-config.cmake.in"

--- a/exporters/fluentd/cmake/opentelemetry-cpp.cmake
+++ b/exporters/fluentd/cmake/opentelemetry-cpp.cmake
@@ -1,5 +1,5 @@
 if("${opentelemetry-cpp-tag}" STREQUAL "")
-	set(opentelemetry-cpp-tag "75c2a8f7a6bf81d9799e76804473609cc236b7be") #to incorporate PR#1325
+	set(opentelemetry-cpp-tag "96534a7c2370099ada8bd9dcdc7236c76adf47d9") # OpenTelemetry C++ v1.4.1
 endif()
 function(target_create _target _lib)
   add_library(${_target} STATIC IMPORTED)

--- a/exporters/fluentd/example/log/main.cc
+++ b/exporters/fluentd/example/log/main.cc
@@ -11,7 +11,10 @@
 
 namespace sdk_logs = opentelemetry::sdk::logs;
 namespace nostd = opentelemetry::nostd;
+
+#ifndef HAVE_CONSOLE_LOG
 #define HAVE_CONSOLE_LOG
+#endif
 
 namespace {
 void initLogger() {

--- a/exporters/fluentd/example/trace/main.cc
+++ b/exporters/fluentd/example/trace/main.cc
@@ -12,7 +12,9 @@
 namespace sdktrace = opentelemetry::sdk::trace;
 namespace nostd = opentelemetry::nostd;
 
+#ifndef HAVE_CONSOLE_LOG
 #define HAVE_CONSOLE_LOG
+#endif
 
 namespace {
 void initTracer() {

--- a/exporters/fluentd/include/opentelemetry/exporters/fluentd/log/recordable.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/fluentd/log/recordable.h
@@ -33,7 +33,7 @@ public:
    * Set name for this log
    * @param name the name to set
    */
-  void SetName(nostd::string_view name) noexcept override;
+  void SetName(nostd::string_view name) noexcept;
 
   /**
    * Set body field for this log.


### PR DESCRIPTION
`SetName` method is now removed in the mainline base class, based on Log spec update here:
https://github.com/open-telemetry/opentelemetry-cpp/pull/1383
https://github.com/open-telemetry/opentelemetry-cpp/commit/280f546e175070b324efc966064a634d300bdf23

This causes the contrib `fluentd` build break when the code is compiled with latest OpenTelemetry SDK!

List of changes:

- **Code change** : remove `override` attribute in fluentd `log/recordable.h` . But keep the method for now. Need to figure out what to do with it in the long run. One possibility is to shim the method to `SetAttribute("name", value)` in a way that won't be affecting the code / customers that might still be using it.

- **Code change** : resolve compilation warnings in examples if `HAVE_CONSOLE_LOG` has been defined as a build option in the upper level makefile.

- **NEW - non-invasive build infra option** : allow to build `fluentd` exporter inside the main build tree via `add_directory`. Main idea here is borrowed from nlohmann-json project `CMakeLists.txt`. If fluentd exporter is plugged into the build via `add_directory` into main OpenTelemetry C++ SDK, then don't really need to post a separate package of it. And don't need to provide own config. As a result - artifacts get deployed as part of the main project install, in one build loop rather than in two build loops. Much faster. The other option (clone and build as main project) still there, without any functional changes to its behavior. I'll supply a separate `README.md` for that "fast deployment" later. That's what we use in our Docker image builds / CI pipeline elsewhere.
