### PR TITLE
fluentd: resolve compatibility issues with OpenTelemetry C++ SDK v1.6.0

### DIFF
--- a/exporters/fluentd/CHANGELOG.md
+++ b/exporters/fluentd/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Guideline to update the version
+
+Increment the:
+
+* MAJOR version when you make incompatible API/ABI changes,
+* MINOR version when you add functionality in a backwards compatible manner, and
+* PATCH version when you make backwards compatible bug fixes.
+
+## [1.2.0] 2022-08-29
+
+* [EXPORTER] OpenTelemetry SDK v1.6.0 compatibility
+
+## [1.1.2] 2022-06-30
+
+* [EXPORTER] OpenTelemetry SDK v1.4.0 compatibility
+
+## [1.1.1] 2022-03-16
+
+* [EXPORTER] OpenTelemetry SDK v1.1.1 compatibility
+

--- a/exporters/fluentd/cmake/opentelemetry-cpp.cmake
+++ b/exporters/fluentd/cmake/opentelemetry-cpp.cmake
@@ -1,5 +1,5 @@
 if("${opentelemetry-cpp-tag}" STREQUAL "")
-	set(opentelemetry-cpp-tag "96534a7c2370099ada8bd9dcdc7236c76adf47d9") # OpenTelemetry C++ v1.4.1
+	set(opentelemetry-cpp-tag "v1.6.0")
 endif()
 function(target_create _target _lib)
   add_library(${_target} STATIC IMPORTED)

--- a/exporters/fluentd/example/fluentd-docker/fluent.conf
+++ b/exporters/fluentd/example/fluentd-docker/fluent.conf
@@ -11,6 +11,10 @@
 ####
 ## Source descriptions:
 ##
+# Concurrent ingestion of OpenTelemetry logs and traces requires more than one system worker thread.
+<system>
+  workers 3
+</system>
 
 ## built-in TCP input
 ## @see http://docs.fluentd.org/articles/in_forward
@@ -22,10 +26,11 @@
 </source>
 
 ## built-in UNIX socket input
-<source>
-  @type unix
-  path /tmp/fluentd/log/socket.sock
-</source>
+# Uncomment for Unix Domain socket support
+#<source>
+#  @type unix
+#  path /tmp/fluentd/log/socket.sock
+#</source>
 
 # HTTP input
 # POST http://localhost:8888/<tag>?json=<json>

--- a/exporters/fluentd/include/opentelemetry/exporters/fluentd/log/recordable.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/fluentd/log/recordable.h
@@ -86,12 +86,12 @@ public:
       opentelemetry::common::SystemTimestamp timestamp) noexcept override;
 
   /**
-   * Set instrumentation_library for this log.
-   * @param instrumentation_library the instrumentation library to set
+   * Set instrumentation_scope for this log.
+   * @param instrumentation_scope the instrumentation scope to set
    */
-  void SetInstrumentationLibrary(
-      const opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary
-          &instrumentation_library) noexcept override {} // Not Supported
+  void SetInstrumentationScope(
+      const opentelemetry::sdk::instrumentationscope::InstrumentationScope
+          &instrumentation_scope) noexcept override {} // Not Supported
 
   nlohmann::json &Log() { return json_; }
 

--- a/exporters/fluentd/include/opentelemetry/exporters/fluentd/trace/recordable.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/fluentd/trace/recordable.h
@@ -67,9 +67,9 @@ public:
 
   void SetDuration(std::chrono::nanoseconds duration) noexcept override;
 
-  void SetInstrumentationLibrary(
-      const opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary
-          &instrumentation_library) noexcept override;
+  void SetInstrumentationScope(
+      const opentelemetry::sdk::instrumentationscope::InstrumentationScope
+          &instrumentation_scope) noexcept override;
 
 private:
   std::string tag_;

--- a/exporters/fluentd/src/trace/recordable.cc
+++ b/exporters/fluentd/src/trace/recordable.cc
@@ -136,12 +136,12 @@ void Recordable::SetSpanKind(
   }
 }
 
-void Recordable::SetInstrumentationLibrary(
-    const opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary
-        &instrumentation_library) noexcept {
-  options_["tags"]["otel.library.name"] = instrumentation_library.GetName();
+void Recordable::SetInstrumentationScope(
+    const opentelemetry::sdk::instrumentationscope::InstrumentationScope
+        &instrumentation_scope) noexcept {
+  options_["tags"]["otel.library.name"] = instrumentation_scope.GetName();
   options_["tags"]["otel.library.version"] =
-      instrumentation_library.GetVersion();
+      instrumentation_scope.GetVersion();
 }
 
 } // namespace trace

--- a/exporters/fluentd/test/trace/fluentd_recordable_test.cc
+++ b/exporters/fluentd/test/trace/fluentd_recordable_test.cc
@@ -133,9 +133,9 @@ TEST(FluentdSpanRecordable, SetDuration)
   EXPECT_EQ(rec.span(), j_span);
 }
 
-TEST(FluentdSpanRecordable, SetInstrumentationLibrary)
+TEST(FluentdSpanRecordable, SetInstrumentationScope)
 {
-  using InstrumentationLibrary = opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary;
+  using InstrumentationScope = opentelemetry::sdk::instrumentationscope::InstrumentationScope;
 
   const char *library_name    = "otel-cpp";
   const char *library_version = "0.5.0";
@@ -143,7 +143,7 @@ TEST(FluentdSpanRecordable, SetInstrumentationLibrary)
       {"tags", {{"otel.library.name", library_name}, {"otel.library.version", library_version}}}};
   opentelemetry::exporter::fluentd::trace::Recordable rec;
 
-  rec.SetInstrumentationLibrary(*InstrumentationLibrary::Create(library_name, library_version));
+  rec.SetInstrumentationScope(*InstrumentationScope::Create(library_name, library_version));
 
   EXPECT_EQ(rec.span(), j_span);
 }


### PR DESCRIPTION
Recent refactor in OpenTelemetry C++ SDK here:
https://github.com/open-telemetry/opentelemetry-cpp/pull/1507
Breaks the fluentd exporter.

Resolve compatibility issues and create new fluentd exporter version compat with v1.6.0.

Added `CHANGELOG.md` to track compatibility notes.