### PR TITLE
Create README.md in instrumentation folder

### DIFF
--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -1,0 +1,9 @@
+# OpenTelemetry C++ instrumentations
+
+In this directory you will find instrumentation libraries and modules.
+
+| Name  |  Description  |
+|---|---|
+| [httpd](./httpd)  |  httpd (Apache) OpenTelemetry module |  
+| [nginx](./nginx) | OpenTelemetry nginx module |
+| [otel-webserver-module](./otel-webserver-module) | The OTEL webserver module comprises of both Apache and Nginx instrumentation. |


### PR DESCRIPTION
Hey, I thought it would be helpful for endusers to understand what they can find in the different directories, especially since it is not clear that otel-webserver-module contains httpd/nginx modules as well.