### PR TITLE
Add support for 'OTEL_SERVICE_NAME' environment variable

### DIFF
--- a/instrumentation/nginx/README.md
+++ b/instrumentation/nginx/README.md
@@ -100,6 +100,7 @@ schedule_delay_millis = 5000
 max_export_batch_size = 512
 
 [service]
+# Can also be set by the OTEL_SERVICE_NAME environment variable.
 name = "nginx-proxy" # Opentelemetry resource name
 
 [sampler]

--- a/instrumentation/nginx/README.md
+++ b/instrumentation/nginx/README.md
@@ -109,6 +109,22 @@ ratio = 0.1
 parent_based = false
 ```
 
+Here's what it would look like if you used the OTLP exporter, but only set the endpoint with an environment variables (e.g. `OTEL_EXPORTER_OTLP_ENDPOINT="localhost:4317"`).
+```toml
+exporter = "otlp"
+processor = "batch"
+
+[exporters.otlp]
+
+[processors.batch]
+max_queue_size = 2048
+schedule_delay_millis = 5000
+max_export_batch_size = 512
+
+[service]
+name = "nginx-proxy" # Opentelemetry resource name
+```
+
 To use other environment variables defined in the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md), must add the "env" directive.
 
 ```

--- a/instrumentation/nginx/src/agent_config.cpp
+++ b/instrumentation/nginx/src/agent_config.cpp
@@ -94,6 +94,14 @@ static bool SetupExporter(toml_table_t* root, ngx_log_t* log, OtelNgxAgentConfig
 }
 
 static bool SetupService(toml_table_t* root, ngx_log_t*, OtelNgxAgentConfig* config) {
+  const char *otel_service_name_env = "OTEL_SERVICE_NAME";
+  auto service_name_from_env = std::getenv(otel_service_name_env);
+
+  if (service_name_from_env) {
+    config->service.name = service_name_from_env;
+    return true;
+  }
+
   toml_table_t* service = toml_table_in(root, "service");
 
   if (service) {


### PR DESCRIPTION
**Background**
Currently, the only way to set a service name is through the `*.toml` configuration. In other OpenTelemetry SDKs, there's support for setting the service name [through use of the `OTEL_SERVICE_NAME` environment variable](https://github.com/open-telemetry/opentelemetry-specification/blob/5accc434c013e9582598048f3df864c97b272dd0/spec-compliance-matrix.md#environment-variables), but it's not currently implemented in the [C++ SDK](https://github.com/open-telemetry/opentelemetry-cpp). 

**Problem**
For most cases, setting the service name through a configuration file is fine. But, this can quickly become painful in an environment where you're running multiple `nginx` services and you'd like to give each their own service name.

The C++ SDK does support the `OTEL_RESOURCE_ATTRIBUTES` header which could be used to overwrite the service name by setting `service.name` (e.g. `OTEL_RESOURCE_ATTRIBUTES="service.name=nginx-proxy"`), but the agent setup [sets a default value](https://github.com/open-telemetry/opentelemetry-cpp-contrib/blob/3c7973b85f19b6a08b38ff4090fa8c641dc1a676/instrumentation/nginx/src/agent_config.h#L21-L23) of `unknown:nginx` which takes precedence over the value in the resource attributes environment variable.

**Solution**
This PR adds support for setting a service name through the `OTEL_SERVICE_NAME` environment variable. There's precedent for supporting OpenTelemetry-specification-valid behaviour that's not yet supported in the upstream C++ SDK (see https://github.com/open-telemetry/opentelemetry-cpp-contrib/pull/25). 

I tried to add some tests for this PR, but I've been running into `jason` decode errors that I've had no luck successfully debugging (it's getting cut off JSON blobs of the traces and, understandably, fails to parse them). I don't have experience with Elixir so can't tell if this is a library problem, an M2 Mac issue, or something else.

I took the liberty to also make some modifications to the README and add an example of using the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable as I lost a good hour trying to debug why it wasn't working for me 😅 

cc @NaurisSadovskis