### PR TITLE
Changing License from Appdynamics to Opentelemetry Author

### DIFF
--- a/instrumentation/otel-webserver-module/include/apache/ApacheConfig.h
+++ b/instrumentation/otel-webserver-module/include/apache/ApacheConfig.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/apache/ApacheHooks.h
+++ b/instrumentation/otel-webserver-module/include/apache/ApacheHooks.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/apache/ExcludedModules.h
+++ b/instrumentation/otel-webserver-module/include/apache/ExcludedModules.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/apache/HookContainer.h
+++ b/instrumentation/otel-webserver-module/include/apache/HookContainer.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/AgentCore.h
+++ b/instrumentation/otel-webserver-module/include/core/AgentCore.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors.  
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/AgentLogger.h
+++ b/instrumentation/otel-webserver-module/include/core/AgentLogger.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/RequestContext.h
+++ b/instrumentation/otel-webserver-module/include/core/RequestContext.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/api/ApiUtils.h
+++ b/instrumentation/otel-webserver-module/include/core/api/ApiUtils.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/api/AppdynamicsSdk.h
+++ b/instrumentation/otel-webserver-module/include/core/api/AppdynamicsSdk.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors.  
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/api/Interface.h
+++ b/instrumentation/otel-webserver-module/include/core/api/Interface.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/api/Payload.h
+++ b/instrumentation/otel-webserver-module/include/core/api/Payload.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/api/RequestProcessingEngine.h
+++ b/instrumentation/otel-webserver-module/include/core/api/RequestProcessingEngine.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors.  
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/api/SpanNamer.h
+++ b/instrumentation/otel-webserver-module/include/core/api/SpanNamer.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/api/TenantConfig.h
+++ b/instrumentation/otel-webserver-module/include/core/api/TenantConfig.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/api/WSAgent.h
+++ b/instrumentation/otel-webserver-module/include/core/api/WSAgent.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/api/opentelemetry_ngx_api.h
+++ b/instrumentation/otel-webserver-module/include/core/api/opentelemetry_ngx_api.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/sdkwrapper/IScopedSpan.h
+++ b/instrumentation/otel-webserver-module/include/core/sdkwrapper/IScopedSpan.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/sdkwrapper/ISdkHelperFactory.h
+++ b/instrumentation/otel-webserver-module/include/core/sdkwrapper/ISdkHelperFactory.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/sdkwrapper/ISdkWrapper.h
+++ b/instrumentation/otel-webserver-module/include/core/sdkwrapper/ISdkWrapper.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/sdkwrapper/ScopedSpan.h
+++ b/instrumentation/otel-webserver-module/include/core/sdkwrapper/ScopedSpan.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkConstants.h
+++ b/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkConstants.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkEnums.h
+++ b/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkEnums.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors.  
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkHelperFactory.h
+++ b/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkHelperFactory.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkUtils.h
+++ b/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkUtils.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors.  
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkWrapper.h
+++ b/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkWrapper.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors.  
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/core/sdkwrapper/ServerSpan.h
+++ b/instrumentation/otel-webserver-module/include/core/sdkwrapper/ServerSpan.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/include/util/SpanNamingUtils.h
+++ b/instrumentation/otel-webserver-module/include/util/SpanNamingUtils.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/apache/ApacheConfig.cpp
+++ b/instrumentation/otel-webserver-module/src/apache/ApacheConfig.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/apache/ApacheHooks.cpp
+++ b/instrumentation/otel-webserver-module/src/apache/ApacheHooks.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/apache/ApacheTracing.cpp
+++ b/instrumentation/otel-webserver-module/src/apache/ApacheTracing.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors.  
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/apache/ApacheTracing.h
+++ b/instrumentation/otel-webserver-module/src/apache/ApacheTracing.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/apache/ExcludedModules.cpp
+++ b/instrumentation/otel-webserver-module/src/apache/ExcludedModules.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/apache/HookContainer.cpp
+++ b/instrumentation/otel-webserver-module/src/apache/HookContainer.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/apache/mod_apache_otel.cpp
+++ b/instrumentation/otel-webserver-module/src/apache/mod_apache_otel.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/core/AgentCore.cpp
+++ b/instrumentation/otel-webserver-module/src/core/AgentCore.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/core/AgentLogger.cpp
+++ b/instrumentation/otel-webserver-module/src/core/AgentLogger.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/core/api/ApiUtils.cpp
+++ b/instrumentation/otel-webserver-module/src/core/api/ApiUtils.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/core/api/RequestProcessingEngine.cpp
+++ b/instrumentation/otel-webserver-module/src/core/api/RequestProcessingEngine.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors.  
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/core/api/SpanNamer.cpp
+++ b/instrumentation/otel-webserver-module/src/core/api/SpanNamer.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/core/api/WSAgent.cpp
+++ b/instrumentation/otel-webserver-module/src/core/api/WSAgent.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors.  
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/core/api/opentelemetry_ngx_api.cpp
+++ b/instrumentation/otel-webserver-module/src/core/api/opentelemetry_ngx_api.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors.  
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/core/sdkwrapper/ScopedSpan.cpp
+++ b/instrumentation/otel-webserver-module/src/core/sdkwrapper/ScopedSpan.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/core/sdkwrapper/SdkHelperFactory.cpp
+++ b/instrumentation/otel-webserver-module/src/core/sdkwrapper/SdkHelperFactory.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/core/sdkwrapper/SdkWrapper.cpp
+++ b/instrumentation/otel-webserver-module/src/core/sdkwrapper/SdkWrapper.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/core/sdkwrapper/ServerSpan.cpp
+++ b/instrumentation/otel-webserver-module/src/core/sdkwrapper/ServerSpan.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/src/util/SpanNamingUtils.cpp
+++ b/instrumentation/otel-webserver-module/src/util/SpanNamingUtils.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/test/unit/AgentCore_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/AgentCore_test.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/test/unit/ApiUtils_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/ApiUtils_test.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC.
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/test/unit/RequestProcessingEngine_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/RequestProcessingEngine_test.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/test/unit/ScopedSpan_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/ScopedSpan_test.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/test/unit/SdkUtils_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/SdkUtils_test.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/test/unit/SdkWrapper_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/SdkWrapper_test.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/test/unit/ServerSpan_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/ServerSpan_test.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/test/unit/SpanNamer_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/SpanNamer_test.cpp
@@ -1,3 +1,18 @@
+/*
+* Copyright 2022, OpenTelemetry Authors. 
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 #include "gtest/gtest.h"
 #include "api/SpanNamer.h"
 #include "SpanNamingUtils.h"

--- a/instrumentation/otel-webserver-module/test/unit/WSAgent_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/WSAgent_test.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/test/unit/integration_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/integration_test.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors. 
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/instrumentation/otel-webserver-module/test/unit/unit_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/unit_test.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2021 AppDynamics LLC. 
+* Copyright 2022, OpenTelemetry Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.


### PR DESCRIPTION
"Copyright 2022, OpenTelemetry Authors" was added and Appdynamics Copyright was removed in All Cpp files 