### PR TITLE
Fix windows build for Geneva Metrics exporter

### DIFF
--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/socket_tools.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/socket_tools.h
@@ -48,6 +48,10 @@
 #include <WinSock2.h>
 #include <Windows.h>
 
+// sa_family_t is not defined in Windows, so typedef-ing it.
+// refer - https://learn.microsoft.com/en-us/windows/win32/winsock/sockaddr-2
+typedef u_short sa_family_t;
+
 #ifdef min
 // NOMINMAX may be a better choice. However, defining it globally may break
 // other. Code that depends on macro definition in Windows SDK.


### PR DESCRIPTION
The windows build breaks with error:

```
  unix_domain_socket_data_transport.cc
C:\Users\labhas\Obs\otel\lalit\opentelemetry-cpp-contrib\exporters\geneva\include\opentelemetry/exporters/geneva/metrics/socket_tools.h(319,21): e
rror C2065: 'sa_family_t': undeclared identifier [C:\Users\labhas\Obs\otel\lalit\opentelemetry-cpp-contrib\exporters\geneva\build\opentelemetry_ex
porter_geneva_metrics.vcxproj]
```

`sa_family_t` was introduced as part of abstract_socket support, and that is breaking the windows build. Fixing it here.

Also we need to add Windows CI build here to catch these errors. Will do it as separate PR.