### PR TITLE
[Geneva Exporter] Add support for exporting metrics to different combinations of account and namespace

### DIFF
--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/exporter.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/exporter.h
@@ -65,10 +65,7 @@ private:
   std::unique_ptr<DataTransport> data_transport_;
 
   // metrics storage
-  char buffer_non_histogram_[kBufferSize];
-  char buffer_histogram_[kBufferSize];
-  uint64_t buffer_index_non_histogram_;
-  uint64_t buffer_index_histogram_;
+  char buffer_[kBufferSize];
 
   size_t InitializeBufferForNonHistogramData();
   size_t InitiaizeBufferForHistogramData();

--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/exporter.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/exporter.h
@@ -33,6 +33,9 @@ constexpr uint64_t kSecondsToUnixTime =
                   // 1601-01-01T00:00:00Z and UNIX/Linux epoch
                   // (1970-01-01T00:00:00Z)
 
+const std::string kAttributeNamespaceKey = "_microsoft_metrics_namespace";
+const std::string kAttributeAccountKey = "_microsoft_metrics_account";
+
 using ValueType = nostd::variant<int64_t, double>;
 
 /**
@@ -67,8 +70,6 @@ private:
   // metrics storage
   char buffer_[kBufferSize];
 
-  size_t InitializeBufferForNonHistogramData();
-  size_t InitiaizeBufferForHistogramData();
   size_t SerializeNonHistogramMetrics(sdk::metrics::AggregationType,
                                       MetricsEventType,
                                       const sdk::metrics::ValueType &,

--- a/exporters/geneva/src/exporter.cc
+++ b/exporters/geneva/src/exporter.cc
@@ -284,7 +284,7 @@ size_t Exporter::SerializeHistogramMetrics(
   auto account_namespace = connection_string_parser_.namespace_;
 
   // try reading namespace and/or account from attributes
-  // TBD = This can be avoided by migrating to the 
+  // TODO: This can be avoided by migrating to the 
   // TLV binary format
   for (const auto &kv : attributes) {
     if (kv.first  == kAttributeAccountKey){
@@ -309,11 +309,27 @@ size_t Exporter::SerializeHistogramMetrics(
                kMaxDimensionNameSize);
       continue;
     }
+    if (kv.first == kAttributeAccountKey ||
+        kv.first == kAttributeNamespaceKey)
+    {
+      // custom namespace and account name should't be exported
+      continue;
+    }
     SerializeString(buffer_, bufferIndex, kv.first);
   }
 
   // dimentions - value
   for (const auto &kv : attributes) {
+    if (kv.first.size() > kMaxDimensionNameSize) {
+      // warning is already logged earlier, no logging again
+      continue;
+    }
+    if (kv.first == kAttributeAccountKey ||
+        kv.first == kAttributeNamespaceKey)
+    {
+      // custom namespace and account name should't be exported
+      continue;
+    }
     auto attr_value = AttributeValueToString(kv.second);
     SerializeString(buffer_, bufferIndex, attr_value);
   }

--- a/exporters/geneva/test/common/generate_metrics.h
+++ b/exporters/geneva/test/common/generate_metrics.h
@@ -88,6 +88,7 @@ const std::string kCounterLongInstrumentDesc =
 const std::string kCounterLongInstrumentUnit =
     "test_instrument_conter_long_unit";
 const long kCounterLongValue = 102;
+const long kCounterCustomLongValue = 103;
 const std::string kCounterLongAttributeKey1 = "counter_long_key1";
 const std::string kCounterLongAttributeValue1 = "counter_long_value1";
 
@@ -100,7 +101,6 @@ GenerateSumDataLongMetrics(
     std::string account_namespace= ""
 ) {
   opentelemetry::sdk::metrics::SumPointData sum_point_data{};
-  sum_point_data.value_ = kCounterLongValue;
   sum_point_data.is_monotonic_ = true;
   opentelemetry::sdk::metrics::ResourceMetrics data;
   auto resource = opentelemetry::sdk::resource::Resource::Create(
@@ -113,8 +113,13 @@ GenerateSumDataLongMetrics(
   {{kCounterLongAttributeKey1,
                 kCounterLongAttributeValue1}};
   if (account_name.size() && account_namespace.size()) {
+    std::cout << "\n Generating custom namespae and metrics for " << kCounterCustomLongValue << "\n";
     attributes[opentelemetry::exporter::geneva::metrics::kAttributeNamespaceKey] = account_namespace;
     attributes[opentelemetry::exporter::geneva::metrics::kAttributeAccountKey] = account_name;
+      sum_point_data.value_ = kCounterCustomLongValue;
+  } else  {
+    std::cout << "\n Generating derfault  namespae and metrics for " << kCounterLongValue << "\n";
+    sum_point_data.value_ = kCounterLongValue;
   }
   opentelemetry::sdk::metrics::MetricData metric_data{
       opentelemetry::sdk::metrics::InstrumentDescriptor{
@@ -252,6 +257,7 @@ const std::string kHistogramLongInstrumentUnit =
     "test_instrument_histogram_long_unit";
 
 const long kHistogramLongSum = 4024l;
+const long kHistogramCustomLongSum = 4025l;
 const long kHistogramLongMin = 3l;
 const long kHistogramLongMax = 1004l;
 const size_t kHistogramLongCount = 10l;
@@ -273,9 +279,7 @@ GenerateHistogramDataLongMetrics(
     std::string account_name = "",
     std::string account_namespace = ""
 ) {
-
   opentelemetry::sdk::metrics::HistogramPointData histogram_point_data{};
-  histogram_point_data.sum_ = kHistogramLongSum;
   histogram_point_data.boundaries_ = kHistogramLongBoundaries;
   histogram_point_data.count_ = kHistogramLongCount;
   histogram_point_data.min_ = kHistogramLongMin;
@@ -295,6 +299,10 @@ GenerateHistogramDataLongMetrics(
   if (account_name.size() && account_namespace.size()) {
     attributes[opentelemetry::exporter::geneva::metrics::kAttributeNamespaceKey] = account_namespace;
     attributes[opentelemetry::exporter::geneva::metrics::kAttributeAccountKey] = account_name;
+    histogram_point_data.sum_ = kHistogramCustomLongSum;
+
+  } else {
+    histogram_point_data.sum_ = kHistogramLongSum;
   }
   opentelemetry::sdk::metrics::MetricData metric_data{
       opentelemetry::sdk::metrics::InstrumentDescriptor{

--- a/exporters/geneva/test/common/generate_metrics.h
+++ b/exporters/geneva/test/common/generate_metrics.h
@@ -30,7 +30,10 @@ const uint16_t kCounterDoubleCountDimensions = 1;
 const uint16_t kCounterDoubleEventId = 55;
 
 static inline opentelemetry::sdk::metrics::ResourceMetrics
-GenerateSumDataDoubleMetrics() {
+GenerateSumDataDoubleMetrics(
+    std::string account_name = "",
+    std::string account_namespace= ""
+) {
   opentelemetry::sdk::metrics::SumPointData sum_point_data1{};
   sum_point_data1.value_ = kCounterDoubleValue1;
   sum_point_data1.is_monotonic_ = true;
@@ -44,6 +47,18 @@ GenerateSumDataDoubleMetrics() {
   auto scope =
       opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create(
           kInstrumentScopeName, kInstrumentScopeVer);
+  opentelemetry::sdk::metrics::PointAttributes attributes1 = 
+  {{kCounterDoubleAttributeKey1,
+                kCounterDoubleAttributeValue1}};
+  opentelemetry::sdk::metrics::PointAttributes attributes2 = 
+  {{kCounterDoubleAttributeKey2, kCounterDoubleAttributeValue2},
+    {kCounterDoubleAttributeKey3, kCounterDoubleAttributeValue3}};
+  if (account_name.size() && account_namespace.size()) {
+    attributes1[opentelemetry::exporter::geneva::metrics::kAttributeNamespaceKey] = account_namespace;
+    attributes1[opentelemetry::exporter::geneva::metrics::kAttributeAccountKey] = account_name;
+    attributes2[opentelemetry::exporter::geneva::metrics::kAttributeNamespaceKey] = account_namespace;
+    attributes2[opentelemetry::exporter::geneva::metrics::kAttributeAccountKey] = account_name;
+  }
   opentelemetry::sdk::metrics::MetricData metric_data{
       opentelemetry::sdk::metrics::InstrumentDescriptor{
           kCounterDoubleInstrumentName, kCounterDoubleInstrumentDesc,
@@ -54,12 +69,9 @@ GenerateSumDataDoubleMetrics() {
       opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
       opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
       std::vector<opentelemetry::sdk::metrics::PointDataAttributes>{
-          {opentelemetry::sdk::metrics::PointAttributes{
-               {kCounterDoubleAttributeKey1, kCounterDoubleAttributeValue1}},
+          {attributes1,
            sum_point_data1},
-          {opentelemetry::sdk::metrics::PointAttributes{
-               {kCounterDoubleAttributeKey2, kCounterDoubleAttributeValue2},
-               {kCounterDoubleAttributeKey3, kCounterDoubleAttributeValue3}},
+          {attributes2,
            sum_point_data2}}};
   data.scope_metric_data_ =
       std::vector<opentelemetry::sdk::metrics::ScopeMetrics>{
@@ -83,7 +95,10 @@ const uint16_t kCounterLongCountDimensions = 1;
 const uint16_t kCounterLongEventId = 50;
 
 static inline opentelemetry::sdk::metrics::ResourceMetrics
-GenerateSumDataLongMetrics() {
+GenerateSumDataLongMetrics(
+    std::string account_name = "",
+    std::string account_namespace= ""
+) {
   opentelemetry::sdk::metrics::SumPointData sum_point_data{};
   sum_point_data.value_ = kCounterLongValue;
   sum_point_data.is_monotonic_ = true;
@@ -94,6 +109,13 @@ GenerateSumDataLongMetrics() {
   auto scope =
       opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create(
           kInstrumentScopeName, kInstrumentScopeVer);
+  opentelemetry::sdk::metrics::PointAttributes attributes = 
+  {{kCounterLongAttributeKey1,
+                kCounterLongAttributeValue1}};
+  if (account_name.size() && account_namespace.size()) {
+    attributes[opentelemetry::exporter::geneva::metrics::kAttributeNamespaceKey] = account_namespace;
+    attributes[opentelemetry::exporter::geneva::metrics::kAttributeAccountKey] = account_name;
+  }
   opentelemetry::sdk::metrics::MetricData metric_data{
       opentelemetry::sdk::metrics::InstrumentDescriptor{
           kCounterLongInstrumentName, kCounterLongInstrumentDesc,
@@ -104,9 +126,7 @@ GenerateSumDataLongMetrics() {
       opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
       opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
       std::vector<opentelemetry::sdk::metrics::PointDataAttributes>{
-          {opentelemetry::sdk::metrics::PointAttributes{
-               {kCounterLongAttributeKey1, kCounterLongAttributeValue1}},
-           sum_point_data}}};
+          {attributes, sum_point_data}}};
   data.scope_metric_data_ =
       std::vector<opentelemetry::sdk::metrics::ScopeMetrics>{
           {scope.get(),
@@ -128,7 +148,10 @@ const std::string kUpDownCounterLongAttributeValue1 =
 const uint16_t kUpDownCounterLongCountDimensions = 1;
 
 static inline opentelemetry::sdk::metrics::ResourceMetrics
-GenerateSumDataLongMetricsNonMonotonic() {
+GenerateSumDataLongMetricsNonMonotonic(
+    std::string account_name = "",
+    std::string account_namespace= ""
+) {
   opentelemetry::sdk::metrics::SumPointData sum_point_data{};
   sum_point_data.value_ = kUpDownCounterLongValue;
   sum_point_data.is_monotonic_ = false;
@@ -139,6 +162,13 @@ GenerateSumDataLongMetricsNonMonotonic() {
   auto scope =
       opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create(
           kInstrumentScopeName, kInstrumentScopeVer);
+  opentelemetry::sdk::metrics::PointAttributes attributes = 
+  {{kUpDownCounterLongAttributeKey1,
+                kUpDownCounterLongAttributeValue1}};
+  if (account_name.size() && account_namespace.size()) {
+    attributes[opentelemetry::exporter::geneva::metrics::kAttributeNamespaceKey] = account_namespace;
+    attributes[opentelemetry::exporter::geneva::metrics::kAttributeAccountKey] = account_name;
+  }
   opentelemetry::sdk::metrics::MetricData metric_data{
       opentelemetry::sdk::metrics::InstrumentDescriptor{
           kUpDownCounterLongInstrumentName, kUpDownCounterLongInstrumentDesc,
@@ -149,10 +179,7 @@ GenerateSumDataLongMetricsNonMonotonic() {
       opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
       opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
       std::vector<opentelemetry::sdk::metrics::PointDataAttributes>{
-          {opentelemetry::sdk::metrics::PointAttributes{
-               {kUpDownCounterLongAttributeKey1,
-                kUpDownCounterLongAttributeValue1}},
-           sum_point_data}}};
+          {attributes, sum_point_data}}};
   data.scope_metric_data_ =
       std::vector<opentelemetry::sdk::metrics::ScopeMetrics>{
           {scope.get(),
@@ -175,7 +202,10 @@ const std::string kUpDownCounterDoubleAttributeValue1 =
 const uint16_t kUpDownCounterDoubleCountDimensions = 1;
 
 static inline opentelemetry::sdk::metrics::ResourceMetrics
-GenerateSumDataDoubleMetricsNonMonotonic() {
+GenerateSumDataDoubleMetricsNonMonotonic(
+    std::string account_name = "",
+    std::string account_namespace = "" 
+) {
   opentelemetry::sdk::metrics::SumPointData sum_point_data1{};
   sum_point_data1.value_ = kUpDownCounterDoubleValue;
   sum_point_data1.is_monotonic_ = false;
@@ -186,6 +216,13 @@ GenerateSumDataDoubleMetricsNonMonotonic() {
   auto scope =
       opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create(
           kInstrumentScopeName, kInstrumentScopeVer);
+  opentelemetry::sdk::metrics::PointAttributes attributes = 
+  {{kUpDownCounterDoubleAttributeKey1,
+                kUpDownCounterDoubleAttributeValue1}};
+  if (account_name.size() && account_namespace.size()) {
+    attributes[opentelemetry::exporter::geneva::metrics::kAttributeNamespaceKey] = account_namespace;
+    attributes[opentelemetry::exporter::geneva::metrics::kAttributeAccountKey] = account_name;
+  }
   opentelemetry::sdk::metrics::MetricData metric_data{
       opentelemetry::sdk::metrics::InstrumentDescriptor{
           kUpDownCounterDoubleInstrumentName,
@@ -197,9 +234,7 @@ GenerateSumDataDoubleMetricsNonMonotonic() {
       opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
       opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
       std::vector<opentelemetry::sdk::metrics::PointDataAttributes>{
-          {opentelemetry::sdk::metrics::PointAttributes{
-               {kUpDownCounterDoubleAttributeKey1,
-                kUpDownCounterDoubleAttributeValue1}},
+          {attributes,
            sum_point_data1}}};
   data.scope_metric_data_ =
       std::vector<opentelemetry::sdk::metrics::ScopeMetrics>{
@@ -234,7 +269,10 @@ const uint16_t kHistogramLongCountDimensions = 1;
 const uint16_t kHistogramLongEventId = 56;
 
 static inline opentelemetry::sdk::metrics::ResourceMetrics
-GenerateHistogramDataLongMetrics() {
+GenerateHistogramDataLongMetrics(
+    std::string account_name = "",
+    std::string account_namespace = ""
+) {
 
   opentelemetry::sdk::metrics::HistogramPointData histogram_point_data{};
   histogram_point_data.sum_ = kHistogramLongSum;
@@ -251,6 +289,13 @@ GenerateHistogramDataLongMetrics() {
   auto scope =
       opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create(
           kInstrumentScopeName, kInstrumentScopeVer);
+  opentelemetry::sdk::metrics::PointAttributes attributes = 
+  {{kHistogramLongAttributeKey1,
+                kHistogramLongAttributeValue1}};
+  if (account_name.size() && account_namespace.size()) {
+    attributes[opentelemetry::exporter::geneva::metrics::kAttributeNamespaceKey] = account_namespace;
+    attributes[opentelemetry::exporter::geneva::metrics::kAttributeAccountKey] = account_name;
+  }
   opentelemetry::sdk::metrics::MetricData metric_data{
       opentelemetry::sdk::metrics::InstrumentDescriptor{
           kHistogramLongInstrumentName, kHistogramLongInstrumentDesc,
@@ -261,9 +306,7 @@ GenerateHistogramDataLongMetrics() {
       opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
       opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
       std::vector<opentelemetry::sdk::metrics::PointDataAttributes>{
-          {opentelemetry::sdk::metrics::PointAttributes{
-               {kHistogramLongAttributeKey1, kHistogramLongAttributeValue1}},
-           histogram_point_data}}};
+          {attributes, histogram_point_data}}};
   data.scope_metric_data_ =
       std::vector<opentelemetry::sdk::metrics::ScopeMetrics>{
           {scope.get(),

--- a/exporters/geneva/test/common/generate_metrics.h
+++ b/exporters/geneva/test/common/generate_metrics.h
@@ -113,12 +113,10 @@ GenerateSumDataLongMetrics(
   {{kCounterLongAttributeKey1,
                 kCounterLongAttributeValue1}};
   if (account_name.size() && account_namespace.size()) {
-    std::cout << "\n Generating custom namespae and metrics for " << kCounterCustomLongValue << "\n";
     attributes[opentelemetry::exporter::geneva::metrics::kAttributeNamespaceKey] = account_namespace;
     attributes[opentelemetry::exporter::geneva::metrics::kAttributeAccountKey] = account_name;
       sum_point_data.value_ = kCounterCustomLongValue;
   } else  {
-    std::cout << "\n Generating derfault  namespae and metrics for " << kCounterLongValue << "\n";
     sum_point_data.value_ = kCounterLongValue;
   }
   opentelemetry::sdk::metrics::MetricData metric_data{

--- a/exporters/geneva/test/decoder/ifx_metrics_bin.cpp
+++ b/exporters/geneva/test/decoder/ifx_metrics_bin.cpp
@@ -4,8 +4,6 @@
 
 #include <iostream>
 ifx_metrics_bin_t::ifx_metrics_bin_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, ifx_metrics_bin_t* p__root) : kaitai::kstruct(p__io) {
-        std::cout << "\nLALIT:ifx_metrics_bin::CONST..";
-
     m__parent = p__parent;
     m__root = this;
     m_body = 0;
@@ -20,9 +18,7 @@ ifx_metrics_bin_t::ifx_metrics_bin_t(kaitai::kstream* p__io, kaitai::kstruct* p_
 }
 
 void ifx_metrics_bin_t::_read() {
-    std::cout << "\nLALIT:ifx_metrics_bin::READ..";
     m_event_id = m__io->read_u2le();
-    std::cout << "\nLALIT:ifx_metrics_bin Event ID:" << m_event_id << "\n";
     m_len_body = m__io->read_u2le();
     m__raw_body = m__io->read_bytes(len_body());
     m__io__raw_body = new kaitai::kstream(m__raw_body);

--- a/exporters/geneva/test/metrics_exporter_test.cc
+++ b/exporters/geneva/test/metrics_exporter_test.cc
@@ -23,6 +23,10 @@ std::string kUnixDomainPathAbstractSocket = "@/tmp/ifx_unix_socket";
 const std::string kNamespaceName = "test_ns";
 const std::string kAccountName = "test_account";
 
+const std::string kCustomNamespaceName = "custom_ns";
+const std::string kCustomAccountName = "custom_account";
+
+
 // "busy sleep" while suggesting that other threads run
 // for a small amount of time
 template <typename timeunit> void yield_for(timeunit duration) {


### PR DESCRIPTION
- Add support for exporting metrics to different combinations of account and namespace
     - reading and configure account and namespace from the attributes if present.
     - ensuring that the account and namespace is not exported as attributes. They should be used only for configuration.
- Removed an optimization that was made earlier by having separate buffers for histogram and non-histogram metrics with pre-serialized account and namespace. All the metrics share the same buffer now since we have to serialize account and namespace on every export call now.