### PR TITLE
Add install(EXPORT...) for the opentelemetry-fluentd-target.

### DIFF
--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -194,4 +194,10 @@ if (MAIN_PROJECT)
     NAMESPACE "${PROJECT_NAME}::"
     FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-target.cmake"
   )
+
+  install(
+    EXPORT "${PROJECT_NAME}-target"
+    NAMESPACE "${PROJECT_NAME}::"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+    
 endif()


### PR DESCRIPTION
Match opentelemetry-cpp's cmake with an install(EXPORT...) rule alongside its export rule. See the PR [here](https://github.com/open-telemetry/opentelemetry-cpp/commit/2b08db2db4cf6c6edc4dfd9d76cb6e18900829b6).

Requested by [this PR](https://github.com/microsoft/vcpkg/pull/32063) for vcpkg.