### PR TITLE
Update to newer CMakeFindDependencyMacro macro to fix usage for vcpkg port.

### DIFF
--- a/exporters/fluentd/cmake/opentelemetry-cpp-fluentd-config.cmake.in
+++ b/exporters/fluentd/cmake/opentelemetry-cpp-fluentd-config.cmake.in
@@ -56,11 +56,8 @@ foreach(_TEST_TARGET IN LISTS _OPENTELEMETRY_CPP_FLUENTD_LIBRARIES_TEST_TARGETS)
         endif()
 endforeach()
 
-
 # handle the QUIETLY and REQUIRED arguments and set opentelemetry-cpp_FOUND to
 # TRUE if all variables listed contain valid results, e.g. valid file paths.
-include("FindPackageHandleStandardArgs")
-find_package_handle_standard_args(
-  ${CMAKE_FIND_PACKAGE_NAME}
-  FOUND_VAR ${CMAKE_FIND_PACKAGE_NAME}_FOUND
-  REQUIRED_VARS OPENTELEMETRY_CPP_FLUENTD_INCLUDE_DIRS OPENTELEMETRY_CPP_FLUENTD_LIBRARIES)
+include(CMakeFindDependencyMacro)
+find_dependency(opentelemetry-cpp CONFIG)
+find_dependency(nlohmann_json CONFIG)


### PR DESCRIPTION
Thanks to @LilyWangLL's expertise by correcting this CMAKE such that the CONFIG file's usage is correct.

I tested via running:

```
niande@NIANDE-DESKTOP:/mnt/x/opentelemetry-cpp-contrib/exporters/fluentd$ cmake -DCMAKE_TOOLCHAIN_FILE=~/vcpkg/scripts/buildsystems/vcpkg.cmake
niande@NIANDE-DESKTOP:/mnt/x/opentelemetry-cpp-contrib/exporters/fluentd$ make
```

This is what the CMAKE experts in vcpkg have recommended.