### PR TITLE
[user_events exporter] Disable building samples and tools from LinuxTracepoint

### DIFF
--- a/exporters/user_events/CMakeLists.txt
+++ b/exporters/user_events/CMakeLists.txt
@@ -10,12 +10,12 @@ endif()
 option(BUILD_EXAMPLE "Build example" ON)
 option(BUILD_TESTING "Build tests" ON)
 
-set(MAIN_PROJECT OFF)
-
 project(opentelemetry-user_events-exporter)
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(MAIN_PROJECT ON)
   message(STATUS "${PROJECT_NAME} is main project")
+else()
+  set(MAIN_PROJECT OFF)
 endif()
 
 if(MAIN_PROJECT)
@@ -26,6 +26,9 @@ if(MAIN_PROJECT)
   find_package(opentelemetry-cpp REQUIRED)
 endif()
 
+# don't build samples and tools from LinuxTracepoints.
+set(BUILD_SAMPLES OFF)
+set(BUILD_TOOLS OFF)
 add_subdirectory(third_party/LinuxTracepoints)
 
 include_directories(include)


### PR DESCRIPTION
Some sample in LinuxTracepoint uses `std::shared_ptr` which can be implemented via pthreads, but it doesn't build with pthread which could cause build error in some environment. But anyway, the sample is not needed in this user_events exporter, so disable it in the build.

The submodule LinuxTracepoint is also updated to the latest.