### PR TITLE
Upgrade fluentd exporter to use latest otel-cpp

### DIFF
--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -22,8 +22,6 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   project(opentelemetry-fluentd)
   set(MAIN_PROJECT ON)
 endif()
-add_definitions(-DHAVE_CONSOLE_LOG)
-add_definitions(-DENABLE_LOGS_PREVIEW)
 
 if (MAIN_PROJECT)
   find_package(opentelemetry-cpp CONFIG QUIET)

--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -32,7 +32,7 @@ if (MAIN_PROJECT)
     build_opentelemetry()
     set(OPENTELEMETRY_CPP_INCLUDE_DIRS "")
     set(OPENTELEMETRY_CPP_LIBRARIES "opentelemetry::libopentelemetry")
-    message("\nopentelemetry-cpp package was not found. Cloned from github")
+    message("opentelemetry-cpp package was not found. Cloned from github")
   endif()
 endif()
 
@@ -46,7 +46,7 @@ else()
   set(nlohmann_json_SOURCE_DIR
       "${CMAKE_SOURCE_DIR}/nlohmann_json/single_include")
   include_directories(${nlohmann_json_SOURCE_DIR})
-  message("\nnlohmann_json package was not found. Cloning from github")
+  message("nlohmann_json package was not found. Cloning from github")
 endif()
 
 find_package(CURL REQUIRED)
@@ -56,12 +56,20 @@ include_directories(include)
 # create fluentd trace exporter
 add_library(opentelemetry_exporter_fluentd_trace src/trace/fluentd_exporter.cc
                                                  src/trace/recordable.cc)
-target_include_directories(opentelemetry_exporter_fluentd_trace
+if(MAIN_PROJECT)
+  target_include_directories(opentelemetry_exporter_fluentd_trace
                            PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS})
-target_link_libraries(
-  opentelemetry_exporter_fluentd_trace
-  PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES}
-  INTERFACE nlohmann_json::nlohmann_json)
+  target_link_libraries(
+    opentelemetry_exporter_fluentd_trace
+    PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES}
+    INTERFACE nlohmann_json::nlohmann_json)
+else()
+  target_link_libraries(
+    opentelemetry_exporter_fluentd_trace
+    PUBLIC opentelemetry_trace opentelemetry_resources opentelemetry_common
+    INTERFACE nlohmann_json::nlohmann_json)
+endif()
+
 set_target_properties(opentelemetry_exporter_fluentd_trace
                       PROPERTIES EXPORT_NAME trace)
 
@@ -69,15 +77,21 @@ set_target_properties(opentelemetry_exporter_fluentd_trace
 
 add_library(opentelemetry_exporter_fluentd_logs src/log/fluentd_exporter.cc
                                                 src/log/recordable.cc)
-target_include_directories(opentelemetry_exporter_fluentd_logs
+if(MAIN_PROJECT)
+  target_include_directories(opentelemetry_exporter_fluentd_logs
                            PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS})
-target_link_libraries(
-  opentelemetry_exporter_fluentd_logs
-  PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES}
-  INTERFACE nlohmann_json::nlohmann_json)
+  target_link_libraries(
+    opentelemetry_exporter_fluentd_logs
+    PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES}
+    INTERFACE nlohmann_json::nlohmann_json)
+else()
+    target_link_libraries(
+      opentelemetry_exporter_fluentd_logs
+      PUBLIC opentelemetry_logs opentelemetry_resources opentelemetry_common
+      INTERFACE nlohmann_json::nlohmann_json)
+endif()
 set_target_properties(opentelemetry_exporter_fluentd_logs PROPERTIES EXPORT_NAME
                                                                      logs)
-
 if(nlohmann_json_clone)
   add_dependencies(opentelemetry_exporter_fluentd_trace
                    nlohmann_json::nlohmann_json)

--- a/exporters/fluentd/example/CMakeLists.txt
+++ b/exporters/fluentd/example/CMakeLists.txt
@@ -7,10 +7,10 @@ target_link_libraries(foo_library_trace opentelemetry_exporter_fluentd_trace
 
 add_executable(fluentd_example_trace trace/main.cc)
 if(MAIN_PROJECT)
-target_link_libraries(fluentd_example_trace ${CMAKE_THREAD_LIBS_INIT}
+  target_link_libraries(fluentd_example_trace ${CMAKE_THREAD_LIBS_INIT}
                       foo_library_trace opentelemetry-cpp::trace)
 else()
-target_link_libraries(fluentd_example_trace ${CMAKE_THREAD_LIBS_INIT}
+  target_link_libraries(fluentd_example_trace ${CMAKE_THREAD_LIBS_INIT}
                       foo_library_trace opentelemetry_trace)
 endif()
 
@@ -21,9 +21,9 @@ target_link_libraries(foo_library_logs opentelemetry_exporter_fluentd_logs
 
 add_executable(fluentd_example_logs log/main.cc)
 if(MAIN_PROJECT)
-target_link_libraries(fluentd_example_logs ${CMAKE_THREAD_LIBS_INIT}
+  target_link_libraries(fluentd_example_logs ${CMAKE_THREAD_LIBS_INIT}
                       foo_library_logs opentelemetry-cpp::logs)
 else()
-target_link_libraries(fluentd_example_logs ${CMAKE_THREAD_LIBS_INIT}
+  target_link_libraries(fluentd_example_logs ${CMAKE_THREAD_LIBS_INIT}
                       foo_library_logs opentelemetry_logs)
 endif()

--- a/exporters/fluentd/example/CMakeLists.txt
+++ b/exporters/fluentd/example/CMakeLists.txt
@@ -6,8 +6,13 @@ target_link_libraries(foo_library_trace opentelemetry_exporter_fluentd_trace
                       ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(fluentd_example_trace trace/main.cc)
+if(MAIN_PROJECT)
 target_link_libraries(fluentd_example_trace ${CMAKE_THREAD_LIBS_INIT}
                       foo_library_trace opentelemetry-cpp::trace)
+else()
+target_link_libraries(fluentd_example_trace ${CMAKE_THREAD_LIBS_INIT}
+                      foo_library_trace opentelemetry_trace)
+endif()
 
 add_library(foo_library_logs log/foo_library/foo_library.cc)
 
@@ -15,5 +20,10 @@ target_link_libraries(foo_library_logs opentelemetry_exporter_fluentd_logs
                       ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(fluentd_example_logs log/main.cc)
+if(MAIN_PROJECT)
 target_link_libraries(fluentd_example_logs ${CMAKE_THREAD_LIBS_INIT}
                       foo_library_logs opentelemetry-cpp::logs)
+else()
+target_link_libraries(fluentd_example_logs ${CMAKE_THREAD_LIBS_INIT}
+                      foo_library_logs opentelemetry_logs)
+endif()

--- a/exporters/fluentd/example/log/foo_library/foo_library.cc
+++ b/exporters/fluentd/example/log/foo_library/foo_library.cc
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#define ENABLE_LOGS_PREVIEW
 #include "opentelemetry/logs/provider.h"
 
 namespace logs = opentelemetry::logs;

--- a/exporters/fluentd/include/opentelemetry/exporters/fluentd/common/fluentd_common.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/fluentd/common/fluentd_common.h
@@ -12,6 +12,10 @@
 
 #include <chrono>
 
+#ifndef ENABLE_LOGS_PREVIEW
+#define ENABLE_LOGS_PREVIEW 1
+#endif
+
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter {
 namespace fluentd {

--- a/exporters/fluentd/include/opentelemetry/exporters/fluentd/log/fluentd_exporter.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/fluentd/log/fluentd_exporter.h
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#define ENABLE_LOGS_PREVIEW 1
-
 #include "opentelemetry/exporters/fluentd/common/socket_tools.h"
 
 #include "opentelemetry/exporters/fluentd/trace/recordable.h"

--- a/exporters/fluentd/include/opentelemetry/exporters/fluentd/log/recordable.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/fluentd/log/recordable.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#define ENABLE_LOGS_PREVIEW 1
-
 #include "nlohmann/json.hpp"
 #include "opentelemetry/sdk/common/attribute_utils.h"
 #include "opentelemetry/sdk/logs/recordable.h"

--- a/exporters/fluentd/src/log/fluentd_exporter.cc
+++ b/exporters/fluentd/src/log/fluentd_exporter.cc
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
+#ifndef HAVE_CONSOLE_LOG
 #define HAVE_CONSOLE_LOG
+#endif
 
 #include "opentelemetry/exporters/fluentd/log/fluentd_exporter.h"
 #include "opentelemetry/exporters/fluentd/log/recordable.h"

--- a/exporters/fluentd/src/log/recordable.cc
+++ b/exporters/fluentd/src/log/recordable.cc
@@ -5,6 +5,10 @@
 #include "opentelemetry/exporters/fluentd/common/fluentd_common.h"
 #include "opentelemetry/exporters/fluentd/common/fluentd_logging.h"
 
+#include "opentelemetry/logs/severity.h"
+#include "opentelemetry/trace/span_id.h"
+#include "opentelemetry/trace/trace_id.h"
+
 #include <chrono>
 #include <map>
 

--- a/exporters/fluentd/src/trace/fluentd_exporter.cc
+++ b/exporters/fluentd/src/trace/fluentd_exporter.cc
@@ -248,7 +248,7 @@ bool FluentdExporter::Send(std::vector<uint8_t> &packet) {
       return true;
     }
 
-    LOG_WARN("send failed, retrying %u ...", retryCount);
+    LOG_WARN("send failed, retrying %u ...", (unsigned int)retryCount);
     // Retry to connect and/or send
   }
 

--- a/exporters/fluentd/src/trace/recordable.cc
+++ b/exporters/fluentd/src/trace/recordable.cc
@@ -5,6 +5,8 @@
 #include "opentelemetry/exporters/fluentd/common/fluentd_common.h"
 #include "opentelemetry/exporters/fluentd/common/fluentd_logging.h"
 
+#include "opentelemetry/sdk/resource/resource.h"
+
 #include <map>
 #include <string>
 

--- a/exporters/fluentd/test/common/msgpack_timestamp.h
+++ b/exporters/fluentd/test/common/msgpack_timestamp.h
@@ -22,7 +22,7 @@ class binary_writer2 : public binary_writer<BasicJsonType, CharType> {
   output_adapter_t<CharType> oa = nullptr;
 
   /// whether we can assume little endianess
-  const bool is_little_endian = little_endianess();
+  const bool is_little_endian = this->little_endianess();
 
 public:
   /*


### PR DESCRIPTION
1. Changes to use latest otel-cpp ( take care of header files inclusion for https://github.com/open-telemetry/opentelemetry-cpp/pull/2182).
2. Handle building from within main repo ( through OPENTELEMETRY_EXTERNAL_COMPONENT_PATH env variable)
3. Fix nit warnings - of type mismatch, and macro redefined.