### PR TITLE
Example of OpenTelemetry FFI Bridge for Rust and C++

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ffi"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cxx = "1.0"
+
+[build-dependencies]
+cxx-build = "1.0"

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -1,0 +1,37 @@
+# OpenTelemetry FFI Bridge for Rust and C++
+
+This code demonstrates the creation of a Foreign Function Interface (FFI) bridge between Rust and C++ using the [cxx crate](https://github.com/dtolnay/cxx). The primary goal is to facilitate interoperability between Rust and C++ codebases, particularly in the context of OpenTelemetry.
+
+## Code Overview
+
+### Create an FFI Bridge
+
+The cxx crate is utilized to establish an FFI bridge between Rust and C++. A Rust module named ffi is defined using the #[cxx::bridge] attribute. Within this module, a Rust struct named TracerProvider is defined. This struct encapsulates a name field and serves as a data structure that can be accessed from C++.
+
+An FFI function named get_tracer_provider() is declared within the extern "Rust" block. This function is designed to be callable from C++ and is expected to return a reference to a TracerProvider instance.
+
+### Rust TracerProvider Implementation
+
+A Rust struct named RustTracerProvider is introduced. This struct is designed to manage a TracerProvider instance. It includes a new() method that initializes a new RustTracerProvider with a default TracerProvider.
+
+### Bridging Rust and C++ with a C Wrapper for OpenTelemetry Integration
+
+By now CXX has some types that are intended to be supported "soon" but are just not implemented yet.
+
+These types are necessary for the instrumentation and configuration of the C++ and Rust interaction within the context of OpenTelemetry.
+
+To mitigate these issues currently, we can follow an approach by creating a C wrapper that acts as an intermediary between Rust and C++. This wrapper will handle these specific types, ensuring a smooth interaction between the two languages.
+
+### Creating a C Wrapper for Rust and C++ Interaction
+
+To address the impending types and provide a way to bridge Rust and C++ effectively, we propose the following steps:
+
+1. **Define the C Interface**: Begin by defining a C interface that will be accessible from both Rust and C++ codebases. This interface should include functions and structures that mirror the expected types. These functions will serve as an abstraction layer for handling the complex types.
+
+2. **Implement the C Wrapper**: In a separate C source file, implement the functions defined in the C interface. The implementation will act as an intermediary between Rust and C++, converting the data structures as needed and making the interaction seamless.
+
+3. **Expose the C Wrapper to Rust and C++**: To access the C wrapper, expose its functions through the FFI mechanisms provided by Rust and C++. This involves creating external function declarations in Rust and including the C header in the C++ codebase.
+
+4. **Utilize the C Wrapper**: In both the Rust and C++ code, replace the direct usage of the "soon-to-be-supported" types with calls to the C wrapper's functions. This ensures that data is properly converted and handled, regardless of the current limitations of CXX.
+
+By adopting this approach, we can ensure a reliable and consistent interaction between Rust and C++ while awaiting the full support of the intended types in CXX. This strategy not only mitigates the current issues but also paves the way for a smoother transition once the desired types are officially implemented.

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,0 +1,30 @@
+use opentelemetry::sdk::trace::TracerProvider;
+
+#[cxx::bridge]
+mod ffi {
+    struct TracerProvider {
+        name: String,
+    }
+
+    extern "Rust" {
+        fn get_tracer_provider() -> &TracerProvider;
+    }
+}
+
+#[derive(Default)]
+pub struct RustTracerProvider {
+    provider: TracerProvider,
+}
+
+impl RustTracerProvider {
+    pub fn new() -> Self {
+        Self {
+            provider: TracerProvider::default(),
+        }
+    }
+}
+
+pub fn get_tracer_provider() -> *mut TracerProvider {
+    let provider = Box::new(RustTracerProvider::new().provider);
+    Box::into_raw(provider)
+}


### PR DESCRIPTION
This pull request adds an example of Foreign Function Interface (FFI) integration between Rust and C++ in the `examples/ffi/` directory.