### PR TITLE
instrumentation/nginx: include batch_span_processor_options to fix build

### DIFF
--- a/instrumentation/nginx/src/otel_ngx_module.cpp
+++ b/instrumentation/nginx/src/otel_ngx_module.cpp
@@ -27,6 +27,7 @@ extern ngx_module_t otel_ngx_module;
 #include <opentelemetry/context/context.h>
 #include <opentelemetry/nostd/shared_ptr.h>
 #include <opentelemetry/sdk/trace/batch_span_processor.h>
+#include <opentelemetry/sdk/trace/batch_span_processor_options.h>
 #include <opentelemetry/sdk/trace/id_generator.h>
 #include <opentelemetry/sdk/trace/samplers/always_off.h>
 #include <opentelemetry/sdk/trace/samplers/always_on.h>


### PR DESCRIPTION
The current build fails as it not able to find BatchSpanProcessorOptions.
This struct is only forward-declared.

```bash
../otel-cpp-contrib/opentelemetry-cpp-contrib-866351ce2422a9d953ded4447bcdea0e587d6a53/instrumentation/nginx/src/otel_ngx_module.cpp: In function 'std::unique_ptr<opentelemetry::v1::sdk::trace::SpanProcessor> CreateProcessor(const OtelNgxAgentConfig*, std::unique_ptr<opentelemetry::v1::sdk::trace::SpanExporter>)':
../otel-cpp-contrib/opentelemetry-cpp-contrib-866351ce2422a9d953ded4447bcdea0e587d6a53/instrumentation/nginx/src/otel_ngx_module.cpp:1039:41: error: aggregate 'opentelemetry::v1::sdk::trace::BatchSpanProcessorOptions opts' has incomplete type and cannot be defined.
 1039 |     sdktrace::BatchSpanProcessorOptions opts;
```

I have also raised a PR with `opentelemetry-cpp` which i feel is the actual place we should add the include.
This PR is to ensure `main` builds with the current `HEAD`.

Related PR: 
- https://github.com/open-telemetry/opentelemetry-cpp/pull/2259
