### PR TITLE
instrumentation/nginx: update documentation to drop deprecated options

### DIFF
--- a/instrumentation/nginx/README.md
+++ b/instrumentation/nginx/README.md
@@ -20,12 +20,12 @@ Additional platforms and/or versions coming soon.
 
 ## Dependencies (for building)
 
-1. [gRPC](https://github.com/grpc/grpc) - currently the only supported exporter is OTLP. This requirement will be lifted
+1. [gRPC](https://github.com/grpc/grpc) - currently the only supported exporter is OTLP_GRPC. This requirement will be lifted
    once more exporters become available.
 2. [opentelemetry-cpp](https://github.com/open-telemetry/opentelemetry-cpp) - opentelemetry-cpp needs to be built with
-   position independent code and OTLP support, e.g.:
+   position independent code and OTLP_GRPC support, e.g.:
 ```
-cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DWITH_OTLP=ON ..
+cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DWITH_OTLP_GRPC=ON ..
 ```
 
 ## Building


### PR DESCRIPTION
opentelemetry-cpp has [deprecated](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/CMakeLists.txt#L165) `WITH_OTLP` cmake option.
It suggests using `WITH_OTLP_GRPC/WITH_OTLP_HTTP` instead.

Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
