### PR TITLE
Update for the ValueType change in the main repo

### DIFF
--- a/exporters/geneva/CMakeLists.txt
+++ b/exporters/geneva/CMakeLists.txt
@@ -82,7 +82,7 @@ if(BUILD_TESTING)
   enable_testing()
   include(GoogleTest)
   # build geneva metrics tests
-  add_compile_definitions(KS_STR_ENCODING_NONE HAVE_UNIX_DOMAIN)
+  add_compile_definitions(KS_STR_ENCODING_NONE)
   add_executable(
     geneva_metrics_exporter_test
     test/metrics_exporter_test.cc test/decoder/ifx_metrics_bin.cpp

--- a/exporters/geneva/test/common/generate_metrics.h
+++ b/exporters/geneva/test/common/generate_metrics.h
@@ -88,8 +88,8 @@ const std::string kCounterLongInstrumentDesc =
     "test_instrument_counter_long_desc";
 const std::string kCounterLongInstrumentUnit =
     "test_instrument_conter_long_unit";
-const long kCounterLongValue = 102;
-const long kCounterCustomLongValue = 103;
+const int64_t kCounterLongValue = 102;
+const int64_t kCounterCustomLongValue = 103;
 const std::string kCounterLongAttributeKey1 = "counter_long_key1";
 const std::string kCounterLongAttributeValue1 = "counter_long_value1";
 
@@ -145,7 +145,7 @@ const std::string kUpDownCounterLongInstrumentDesc =
     "test_instrument_up_down_counter_long_desc";
 const std::string kUpDownCounterLongInstrumentUnit =
     "test_instrument_up_down_conter_long_unit";
-const long kUpDownCounterLongValue = -10;
+const int64_t kUpDownCounterLongValue = -10;
 const std::string kUpDownCounterLongAttributeKey1 = "up_down_counter_long_key1";
 const std::string kUpDownCounterLongAttributeValue1 =
     "up_down_counter_long_value1";
@@ -255,10 +255,10 @@ const std::string kHistogramLongInstrumentDesc =
 const std::string kHistogramLongInstrumentUnit =
     "test_instrument_histogram_long_unit";
 
-const long kHistogramLongSum = 4024l;
-const long kHistogramCustomLongSum = 4025l;
-const long kHistogramLongMin = 3l;
-const long kHistogramLongMax = 1004l;
+const int64_t kHistogramLongSum = 4024l;
+const int64_t kHistogramCustomLongSum = 4025l;
+const int64_t kHistogramLongMin = 3l;
+const int64_t kHistogramLongMax = 1004l;
 const size_t kHistogramLongCount = 10l;
 const uint16_t kHistogramLongBucketSize = 10;
 const uint16_t kHistogramLongNonEmptyBucketSize = 8;


### PR DESCRIPTION
The main repo metrics SDK switched to explicit 64-bit. This PR ingest the change in Geneva exporter.

https://github.com/open-telemetry/opentelemetry-cpp/pull/1686