### PR TITLE
[Logs SDK] Log Appender for Boost.Log

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,61 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# See Clang docs: http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+BasedOnStyle: Chromium
+
+# Allow double brackets such as std::vector<std::vector<int>>.
+Standard: Cpp11
+
+# Indent 2 spaces at a time.
+IndentWidth: 2
+
+# Keep lines under 100 columns long.
+ColumnLimit: 100
+
+# Always break before braces
+BreakBeforeBraces: Custom
+BraceWrapping:
+#  TODO(lujc) wait for clang-format-9 support in Chromium tools
+#  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+
+  # Keeps extern "C" blocks unindented.
+  AfterExternBlock: false
+
+# Indent case labels.
+IndentCaseLabels: true
+
+# Right-align pointers and references
+PointerAlignment: Right
+
+# ANGLE likes to align things as much as possible.
+AlignOperands: true
+AlignConsecutiveAssignments: true
+
+# Use 2 space negative offset for access modifiers
+AccessModifierOffset: -2
+
+# TODO(jmadill): Decide if we want this on. Doesn't have an "all or none" mode.
+AllowShortCaseLabelsOnASingleLine: false
+
+# Useful for spacing out functions in classes
+KeepEmptyLinesAtTheStartOfBlocks: true
+
+# Indent nested PP directives.
+IndentPPDirectives: AfterHash
+
+# Include blocks style
+IncludeBlocks: Preserve

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -4,6 +4,7 @@ In this directory you will find instrumentation libraries and modules.
 
 | Name  |  Description  |
 |---|---|
+| [boost-log](./boost_log) | Boost.Log OpenTelemetry sink backend |  
 | [httpd](./httpd)  |  httpd (Apache) OpenTelemetry module |  
 | [nginx](./nginx) | OpenTelemetry nginx module |
 | [otel-webserver-module](./otel-webserver-module) | The OTEL webserver module comprises of both Apache and Nginx instrumentation. |

--- a/instrumentation/boost_log/CMakeLists.txt
+++ b/instrumentation/boost_log/CMakeLists.txt
@@ -1,0 +1,117 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.12)
+
+set(this_target opentelemetry_boost_log_sink)
+
+project(${this_target})
+
+find_package(opentelemetry-cpp REQUIRED)
+find_package(Boost COMPONENTS log REQUIRED)
+
+add_library(${this_target} src/sink.cc)
+
+target_compile_options(${this_target} PUBLIC
+  -Wall -Wextra -Werror -Wpedantic -fPIC -std=c++14
+)
+
+set_target_properties(${this_target} PROPERTIES EXPORT_NAME ${this_target})
+
+target_include_directories(${this_target} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+)
+
+target_link_libraries(${this_target} PRIVATE
+  Boost::log
+)
+
+if(OPENTELEMETRY_INSTALL)
+  include(GNUInstallDirs)
+  include(CMakePackageConfigHelpers)
+
+  install(
+    TARGETS ${this_target}
+    EXPORT "${PROJECT_NAME}-target"
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+  install(
+    DIRECTORY include/opentelemetry/instrumentation/boost_log
+    DESTINATION include/opentelemetry/instrumentation
+    FILES_MATCHING
+    PATTERN "*.h")
+
+  configure_package_config_file(
+    "${CMAKE_CURRENT_LIST_DIR}/${PROJECT_NAME}-config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+  install(
+    FILES
+      "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-config.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+  export(
+    EXPORT "${PROJECT_NAME}-target"
+    NAMESPACE ${PROJECT_NAME}::
+    FILE "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/${PROJECT_NAME}-target.cmake")
+
+  install(
+    EXPORT "${PROJECT_NAME}-target"
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+endif() # OPENTELEMETRY_INSTALL
+
+if(BUILD_TESTING)
+  set(testname sink_test)
+
+  include(GoogleTest)
+
+  add_executable(${testname} "test/${testname}.cc")
+
+  target_include_directories(${testname} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/include
+    ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+  )
+
+  target_link_libraries(${testname} PRIVATE
+    gmock
+    gtest
+    gtest_main
+    Boost::log
+    opentelemetry-cpp::ostream_log_record_exporter
+    ${this_target}
+  )
+
+  gtest_add_tests(
+    TARGET ${testname}
+    TEST_PREFIX intrumentation.boost_log.
+    TEST_LIST ${testname}
+  )
+endif() # BUILD_TESTING
+
+if(WITH_EXAMPLES)
+  set(example_exe otel_sink_example)
+  add_executable(${example_exe} example/main.cc)
+  set_target_properties(${example_exe} PROPERTIES EXPORT_NAME ${example_exe})
+
+  target_include_directories(${example_exe} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/include
+    ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+  )
+
+  target_link_libraries(${example_exe} PRIVATE
+    opentelemetry-cpp::logs
+    opentelemetry-cpp::trace
+    opentelemetry-cpp::ostream_log_record_exporter
+    opentelemetry-cpp::ostream_span_exporter
+    Boost::log
+    ${this_target}
+  )
+endif() # WITH_EXAMPLES

--- a/instrumentation/boost_log/CMakeLists.txt
+++ b/instrumentation/boost_log/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Boost COMPONENTS log REQUIRED)
 add_library(${this_target} src/sink.cc)
 
 target_compile_options(${this_target} PUBLIC
-  -Wall -Wextra -Werror -Wpedantic -fPIC -std=c++14
+  -Wall -Wextra -Werror -Wpedantic -fPIC
 )
 
 set_target_properties(${this_target} PROPERTIES EXPORT_NAME ${this_target})

--- a/instrumentation/boost_log/README.md
+++ b/instrumentation/boost_log/README.md
@@ -27,8 +27,8 @@ The simplest scenario is by creating a logger with the `OpenTelemetrySinkBackend
 using opentelemetry::instrumentation::boost_log::OpenTelemetrySinkBackend;
 
 auto backend = boost::make_shared<OpenTelemetrySinkBackend>();
-auto sink    = boost::make_shared<sinks::synchronous_sink<OpenTelemetrySinkBackend>>(backend);
-logging::core::get()->add_sink(sink);
+auto sink    = boost::make_shared<boost::log::sinks::synchronous_sink<OpenTelemetrySinkBackend>>(backend);
+boost::log::core::get()->add_sink(sink);
 ```
 
 This will create a backend with the following assumptions about the attributes it collects, more precisely:
@@ -92,8 +92,8 @@ mappers.ToSeverity = [](const boost::log::record_view &record) {
 };
 
 auto backend = boost::make_shared<OpenTelemetrySinkBackend>(mappers);
-auto sink    = boost::make_shared<sinks::synchronous_sink<OpenTelemetrySinkBackend>>(backend);
-logging::core::get()->add_sink(sink);
+auto sink    = boost::make_shared<boost::log::sinks::synchronous_sink<OpenTelemetrySinkBackend>>(backend);
+boost::log::core::get()->add_sink(sink);
 ```
 
 Another, although somewhat impractical, example of setting a custom timestamp:
@@ -243,10 +243,10 @@ The above calls the same macro as in the previous example, with the values added
 The default behavior to log the source location is by adding attributes values to the BOOST_LOG* macro with the following keywords:
 
 ```cpp
-BOOST_LOG_SEV(logger, logging::trivial::debug)
+BOOST_LOG_SEV(logger, boost::log::trivial::debug)
     << boost::log::add_value("FileName", __FILE__)
     << boost::log::add_value("FunctionName", __FUNCTION__)
-    << boost::log::add_value("LineNumber", int{__LINE__}) << "Test message with source location";
+    << boost::log::add_value("LineNumber", __LINE__) << "Test message with source location";
 ```
 
 If logging with a different keyword or type, a custom mapping method has to be provided when instantiating the backend sink, as shown in [configuration](#configuration) section.

--- a/instrumentation/boost_log/README.md
+++ b/instrumentation/boost_log/README.md
@@ -1,0 +1,247 @@
+# Boost log OpenTelemetry sink backend
+
+## Features
+
+- Supports Boost.Log sink backend mechanism both, single- and multi-threaded
+- Supports OpenTelemetry SDK without any changes
+
+## Requirements
+
+- Current release tested only with Ubuntu 20.04.6 LTS
+- OpenTelemetry >= v1.12.0 
+- Boost.Log >= v1.73.0
+
+### Usage
+
+Please see below for [manual build](#build). Otherwise please use one of the [released versions](https://github.com/open-telemetry/opentelemetry-cpp-contrib/releases).
+
+### Configuration
+
+The OpenTelemetry sink can be configured in much the same way as any other Boost log sink backend.
+
+The simplest scenario is by creating a logger with the `OpenTelemetrySinkBackend`:
+
+```cpp
+#include <opentelemetry/instrumentation/boost_log/sink.h>
+
+using opentelemetry::instrumentation::boost_log::OpenTelemetrySinkBackend;
+
+auto backend = boost::make_shared<OpenTelemetrySinkBackend>();
+auto sink    = boost::make_shared<sinks::synchronous_sink<OpenTelemetrySinkBackend>>(backend);
+logging::core::get()->add_sink(sink);
+```
+
+This will create a backend with the following assumptions about the attributes it collects, more precisely:
+
+| Keyword      | Type                        |
+|--------------|-----------------------------|
+| Severity     | int                         |
+| TimeStamp    | boost::posix_time::ptime    |
+| ThreadID     | boost::log::aux::thread::id |
+| FileName     | std::string                 |
+| FunctionName | std::string                 |
+| LineNumber   | int                         |
+
+If, however, one or more of these attributes have a different name or type, it is possible to communicate this to the backend via the `ValueMappers` struct.
+It contains a function for each attribute describe above, with the following signatures:
+
+```cpp
+opentelemetry::logs::Severity ToSeverity(const boost::log::record_view &);
+bool ToTimestamp(const boost::log::record_view &record, std::chrono::system_clock::time_point &value);
+bool ToThreadId(const boost::log::record_view &record, std::string &value);
+bool ToFileName(const boost::log::record_view &record, std::string &value);
+bool ToFuncName(const boost::log::record_view &record, std::string &value);
+bool ToLineNumber(const boost::log::record_view &record, int &value);
+```
+
+With the exception of `ToSeverity`, which retrieves the value from the **record** for the attribute with *"Severity"* keyword, and is required to return some OpenTelemetry severity type, the other methods take an additional *out* parameter and return a boolean to indicate success or failure.
+
+As an example of usage, below is one way to create the OTel sink backend with a custom `ToSeverity` method that maps to an enum class `CustomSeverity`` and reads the value from the attribute *"LogLevel"* instead of the default *"Severity"*:
+
+```cpp
+enum class CustomSeverity
+{
+  kRed, kOrange, kYellow, kGreen, kBlue, kIndigo, kViolet
+};
+
+opentelemetry::instrumentation::boost_log::ValueMappers mappers;
+mappers.ToSeverity = [](const boost::log::record_view &record) {
+  if (const auto &result = boost::log::extract<CustomSeverity>(record["LogLevel"]))
+  {
+    switch (result.get())
+    {
+      case CustomSeverity::kRed:
+        return opentelemetry::logs::Severity::kFatal;
+      case CustomSeverity::kOrange:
+        return opentelemetry::logs::Severity::kError;
+      case CustomSeverity::kYellow:
+        return opentelemetry::logs::Severity::kWarn;
+      case CustomSeverity::kGreen:
+        return opentelemetry::logs::Severity::kInfo;
+      case CustomSeverity::kBlue:
+        return opentelemetry::logs::Severity::kDebug;
+      case CustomSeverity::kIndigo:
+        return opentelemetry::logs::Severity::kTrace;
+      case CustomSeverity::kViolet:
+        [[fallthrough]];
+      default: 
+        return Severity::kInvalid;
+    }
+  }
+
+  return opentelemetry::logs::Severity::kInvalid;
+};
+
+auto backend = boost::make_shared<OpenTelemetrySinkBackend>(mappers);
+auto sink    = boost::make_shared<sinks::synchronous_sink<OpenTelemetrySinkBackend>>(backend);
+logging::core::get()->add_sink(sink);
+```
+
+For more details, refer to the [examples](#examples) section.
+
+## Development
+
+### Requirements
+
+- C++14
+- CMake 3.x
+- [OpenTelemetry-cpp](https://github.com/open-telemetry/opentelemetry-cpp)
+- [Boost.Log](https://github.com/boostorg/log)
+- vcpkg **_(optional)_**
+
+### Build
+As a preparation step, both dependencies need to be built and available in the development environment. This can be a manual build, by following the instructions for the corresponding package, or one could opt to use a package management system such as _vcpkg_ or _conan_.
+
+Assuming the packages are available on the system, configure CMake as usual:
+
+```bash
+mkdir build
+cd build
+cmake [path/to/opentelemetry-cpp-contrib]/instrumentation/boost_log -DBUILD_SHARED_LIBS=ON
+make
+```
+
+Optionally, if the packages were provided via vcpkg, pass in to the _cmake_ command above the flag `-DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake` where VCPKG_ROOT is where vcpkg was installed. 
+
+Now, simply link the target source (i.e., main.cc in the example below) against _boost_log_ as well as _opentelemetry_boost_log_sink_:
+
+```bash
+g++ main.cc -lboost_log -lopentelemetry_boost_log_sink -o main
+```
+
+### Installation ###
+
+When configuring the build, if the flag `-DOPENTELEMETRY_INSTALL=ON` is passed, CMake will ensure to set up the install scripts. Once the build succeeds, running `make install` will make the sink header(s) and library available under the usr include and lib directories, respectively.
+
+### Testing
+
+A small suite of unit tests is available under the `test` directory. It can be enabled by passing `-DBUILD_TESTING=ON` when configuring CMake, which will generate an executable called **sink_test**.
+
+### Examples
+
+An example executable is available to test the functionality of the sink. For ease of setup, it uses the _OStreamLogRecordExporter_ to display the contents of the intercepted Boost log message as an OTel _LogRecord_. It can be generated by adding `-DWITH_EXAMPLES=ON` when configuring CMake, which will ultimately produce the **otel_sink_example** executable.
+
+Running  `./otel_sink_example` would produce an output similar to following excerpts.
+
+```
+{
+  timestamp          : 1704766376214174000
+  observed_timestamp : 1704766376214298462
+  severity_num       : 0
+  severity_text      : INVALID
+  body               : Test simplest message
+  resource           :
+    service.name: unknown_service
+    telemetry.sdk.version: 1.12.0
+    telemetry.sdk.name: opentelemetry
+    telemetry.sdk.language: cpp
+  attributes         :
+    thread.id: 0x00007f5d78f932c0
+  event_id           : 0
+  event_name         :
+  trace_id           : 3b74715eaab1e0026feff669ee7f27a1
+  span_id            : a51c93eef9e7af66
+  trace_flags        : 01
+  scope              :
+    name             : Boost.Log
+    version          : 1.83.0
+    schema_url       :
+    attributes       :
+}
+```
+The above is an example of calling BOOST_LOG with a simple logger that is not severity-aware and, as such, the severity is invalid. 
+
+```
+{
+  timestamp          : 1704766376214570000
+  observed_timestamp : 1704766376214576298
+  severity_num       : 9
+  severity_text      : INFO
+  body               : Test message with severity
+  resource           :
+    service.name: unknown_service
+    telemetry.sdk.version: 1.12.0
+    telemetry.sdk.name: opentelemetry
+    telemetry.sdk.language: cpp
+  attributes         :
+    thread.id: 0x00007f5d78f932c0
+  event_id           : 0
+  event_name         :
+  trace_id           : 3b74715eaab1e0026feff669ee7f27a1
+  span_id            : a51c93eef9e7af66
+  trace_flags        : 01
+  scope              :
+    name             : Boost.Log
+    version          : 1.83.0
+    schema_url       :
+    attributes       :
+}
+```
+This example is the result of calling BOOST_LOG_SEV with a severity logger and  trivial severity level.  
+
+```
+{
+  timestamp          : 1704766376214627000
+  observed_timestamp : 1704766376214643807
+  severity_num       : 5
+  severity_text      : DEBUG
+  body               : Test message with source location
+  resource           :
+    service.name: unknown_service
+    telemetry.sdk.version: 1.12.0
+    telemetry.sdk.name: opentelemetry
+    telemetry.sdk.language: cpp
+  attributes         :
+    code.lineno: 90
+    code.function: main
+    code.filepath: /otel-contrib/instrumentation/boost_log/example/main.cc
+    thread.id: 0x00007f5d78f932c0
+  event_id           : 0
+  event_name         :
+  trace_id           : 3b74715eaab1e0026feff669ee7f27a1
+  span_id            : a51c93eef9e7af66
+  trace_flags        : 01
+  scope              :
+    name             : Boost.Log
+    version          : 1.83.0
+    schema_url       :
+    attributes       :
+}
+```
+
+The above calls the same macro as in the previous example, with the values added for the source location (line / function / file).
+
+The default behavior to log the source location is by adding attributes values to the BOOST_LOG* macro with the following keywords:
+
+```cpp
+BOOST_LOG_SEV(logger, logging::trivial::debug)
+    << boost::log::add_value("FileName", __FILE__)
+    << boost::log::add_value("FunctionName", __FUNCTION__)
+    << boost::log::add_value("LineNumber", int{__LINE__}) << "Test message with source location";
+```
+
+If logging with a different keyword or type, a custom mapping method has to be provided when instantiating the backend sink, as shown in [configuration](#configuration) section.
+
+For all the examples, the common attributes were enabled with `boost::log::add_common_attributes();`. Otherwise, the timestamp would not be populated and thread ID would not be included at all in the exported log record.
+
+This example will also output a span with the same ID as the log record, to showcase how the two signals can be correlated via trace and/or span ID.

--- a/instrumentation/boost_log/example/main.cc
+++ b/instrumentation/boost_log/example/main.cc
@@ -35,10 +35,6 @@ namespace trace_exp = opentelemetry::exporter::trace;
 namespace trace_api = opentelemetry::trace;
 namespace trace_sdk = opentelemetry::sdk::trace;
 
-namespace logging = boost::log;
-namespace sinks   = boost::log::sinks;
-namespace src     = boost::log::sources;
-
 int main(int /* argc */, char ** /* argv */)
 {
   // Set up logger provider
@@ -69,21 +65,22 @@ int main(int /* argc */, char ** /* argv */)
 
   // Set up loggers
   {
+    using boost::log::sinks::synchronous_sink;
     using opentelemetry::instrumentation::boost_log::OpenTelemetrySinkBackend;
     auto backend = boost::make_shared<OpenTelemetrySinkBackend>();
-    auto sink    = boost::make_shared<sinks::synchronous_sink<OpenTelemetrySinkBackend>>(backend);
-    logging::core::get()->add_sink(sink);
-    logging::add_common_attributes();
+    auto sink    = boost::make_shared<synchronous_sink<OpenTelemetrySinkBackend>>(backend);
+    boost::log::core::get()->add_sink(sink);
+    boost::log::add_common_attributes();
   }
 
-  src::logger simple;
+  boost::log::sources::logger simple;
   BOOST_LOG(simple) << "Test simplest message";
 
-  src::severity_logger<int> logger;
-  BOOST_LOG_SEV(logger, logging::trivial::info) << "Test message with severity";
+  boost::log::sources::severity_logger<int> logger;
+  BOOST_LOG_SEV(logger, boost::log::trivial::info) << "Test message with severity";
 
-  BOOST_LOG_SEV(logger, logging::trivial::debug)
+  BOOST_LOG_SEV(logger, boost::log::trivial::debug)
       << boost::log::add_value("FileName", __FILE__)
       << boost::log::add_value("FunctionName", __FUNCTION__)
-      << boost::log::add_value("LineNumber", int{__LINE__}) << "Test message with source location";
+      << boost::log::add_value("LineNumber", __LINE__) << "Test message with source location";
 }

--- a/instrumentation/boost_log/example/main.cc
+++ b/instrumentation/boost_log/example/main.cc
@@ -1,0 +1,89 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sources/logger.hpp>
+#include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
+#include <boost/smart_ptr/make_shared_object.hpp>
+
+#include <opentelemetry/instrumentation/boost_log/sink.h>
+
+#include <opentelemetry/sdk/version/version.h>
+
+#include <opentelemetry/exporters/ostream/log_record_exporter_factory.h>
+#include <opentelemetry/logs/provider.h>
+#include <opentelemetry/sdk/logs/exporter.h>
+#include <opentelemetry/sdk/logs/logger_provider_factory.h>
+#include <opentelemetry/sdk/logs/processor.h>
+#include <opentelemetry/sdk/logs/simple_log_record_processor_factory.h>
+
+#include <opentelemetry/exporters/ostream/span_exporter_factory.h>
+#include <opentelemetry/sdk/trace/exporter.h>
+#include <opentelemetry/sdk/trace/processor.h>
+#include <opentelemetry/sdk/trace/simple_processor_factory.h>
+#include <opentelemetry/sdk/trace/tracer_provider_factory.h>
+#include <opentelemetry/trace/provider.h>
+
+namespace context   = opentelemetry::context;
+namespace logs_exp  = opentelemetry::exporter::logs;
+namespace logs_api  = opentelemetry::logs;
+namespace logs_sdk  = opentelemetry::sdk::logs;
+namespace trace_exp = opentelemetry::exporter::trace;
+namespace trace_api = opentelemetry::trace;
+namespace trace_sdk = opentelemetry::sdk::trace;
+
+namespace logging = boost::log;
+namespace sinks   = boost::log::sinks;
+namespace src     = boost::log::sources;
+
+int main(int /* argc */, char ** /* argv */)
+{
+  // Set up logger provider
+  {
+    using ProviderPtr = opentelemetry::nostd::shared_ptr<logs_api::LoggerProvider>;
+    auto exporter     = logs_exp::OStreamLogRecordExporterFactory::Create();
+    auto processor    = logs_sdk::SimpleLogRecordProcessorFactory::Create(std::move(exporter));
+    auto provider     = logs_sdk::LoggerProviderFactory::Create(std::move(processor));
+    logs_api::Provider::SetLoggerProvider(ProviderPtr(provider.release()));
+  }
+
+  // Set up tracer provider
+  {
+    using ProviderPtr = opentelemetry::nostd::shared_ptr<trace_api::TracerProvider>;
+    auto exporter     = trace_exp::OStreamSpanExporterFactory::Create();
+    auto processor    = trace_sdk::SimpleSpanProcessorFactory::Create(std::move(exporter));
+    auto provider     = trace_sdk::TracerProviderFactory::Create(std::move(processor));
+    trace_api::Provider::SetTracerProvider(ProviderPtr(provider.release()));
+  }
+
+  // Set up trace, span and context
+  auto tracer  = trace_api::Provider::GetTracerProvider()->GetTracer("boost_library",
+                                                                     OPENTELEMETRY_SDK_VERSION);
+  auto span    = tracer->StartSpan("boost log test span");
+  auto ctx     = context::RuntimeContext::GetCurrent();
+  auto new_ctx = ctx.SetValue("active_span", span);
+  auto token   = context::RuntimeContext::Attach(new_ctx);
+
+  // Set up loggers
+  {
+    using opentelemetry::instrumentation::boost_log::OpenTelemetrySinkBackend;
+    auto backend = boost::make_shared<OpenTelemetrySinkBackend>();
+    auto sink    = boost::make_shared<sinks::synchronous_sink<OpenTelemetrySinkBackend>>(backend);
+    logging::core::get()->add_sink(sink);
+    logging::add_common_attributes();
+  }
+
+  src::logger simple;
+  BOOST_LOG(simple) << "Test simplest message";
+
+  src::severity_logger<int> logger;
+  BOOST_LOG_SEV(logger, logging::trivial::info) << "Test message with severity";
+
+  BOOST_LOG_SEV(logger, logging::trivial::debug)
+      << boost::log::add_value("FileName", __FILE__)
+      << boost::log::add_value("FunctionName", __FUNCTION__)
+      << boost::log::add_value("LineNumber", int{__LINE__}) << "Test message with source location";
+}

--- a/instrumentation/boost_log/include/opentelemetry/instrumentation/boost_log/sink.h
+++ b/instrumentation/boost_log/include/opentelemetry/instrumentation/boost_log/sink.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <opentelemetry/common/attribute_value.h>
+#include <opentelemetry/logs/log_record.h>
+#include <opentelemetry/logs/severity.h>
+
+#include <boost/log/sinks/basic_sink_backend.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/version.hpp>
+
+#include <chrono>
+#include <functional>
+
+namespace opentelemetry
+{
+namespace instrumentation
+{
+namespace boost_log
+{
+
+using IntMapper    = std::function<bool(const boost::log::record_view &, int &)>;
+using StringMapper = std::function<bool(const boost::log::record_view &, std::string &)>;
+using SeverityMapper =
+    std::function<opentelemetry::logs::Severity(const boost::log::record_view &)>;
+using TimeStampMapper =
+    std::function<bool(const boost::log::record_view &, std::chrono::system_clock::time_point &)>;
+
+using IntSetter       = std::function<void(opentelemetry::logs::LogRecord *, int)>;
+using StringSetter    = std::function<void(opentelemetry::logs::LogRecord *, const std::string &)>;
+using TimeStampSetter = std::function<void(opentelemetry::logs::LogRecord *,
+                                           const std::chrono::system_clock::time_point &)>;
+
+struct ValueMappers
+{
+  SeverityMapper ToSeverity;
+  TimeStampMapper ToTimeStamp;
+  StringMapper ToThreadId;
+  StringMapper ToCodeFile;
+  StringMapper ToCodeFunc;
+  IntMapper ToCodeLine;
+};
+
+class OpenTelemetrySinkBackend
+    : public boost::log::sinks::basic_sink_backend<boost::log::sinks::synchronized_feeding>
+{
+public:
+  static const std::string &libraryVersion()
+  {
+    static const std::string kLibraryVersion = std::to_string(BOOST_VERSION / 100000) + "." +
+                                               std::to_string(BOOST_VERSION / 100 % 1000) + "." +
+                                               std::to_string(BOOST_VERSION % 100);
+    return kLibraryVersion;
+  }
+
+  static inline opentelemetry::logs::Severity levelToSeverity(int level) noexcept
+  {
+    using namespace boost::log::trivial;
+    using opentelemetry::logs::Severity;
+
+    switch (level)
+    {
+      case severity_level::fatal:
+        return Severity::kFatal;
+      case severity_level::error:
+        return Severity::kError;
+      case severity_level::warning:
+        return Severity::kWarn;
+      case severity_level::info:
+        return Severity::kInfo;
+      case severity_level::debug:
+        return Severity::kDebug;
+      case severity_level::trace:
+        return Severity::kTrace;
+      default:
+        return Severity::kInvalid;
+    }
+  }
+
+  OpenTelemetrySinkBackend() noexcept : OpenTelemetrySinkBackend(ValueMappers{}) {}
+
+  explicit OpenTelemetrySinkBackend(const ValueMappers &) noexcept;
+
+  void consume(const boost::log::record_view &);
+
+private:
+  ValueMappers mappers_;
+  std::array<TimeStampSetter, 2> set_timestamp_if_valid_;
+  std::array<StringSetter, 2> set_thread_id_if_valid_;
+  std::array<StringSetter, 2> set_file_path_if_valid_;
+  std::array<StringSetter, 2> set_func_name_if_valid_;
+  std::array<IntSetter, 2> set_code_line_if_valid_;
+};
+
+}  // namespace boost_log
+}  // namespace instrumentation
+}  // namespace opentelemetry

--- a/instrumentation/boost_log/include/opentelemetry/instrumentation/boost_log/sink.h
+++ b/instrumentation/boost_log/include/opentelemetry/instrumentation/boost_log/sink.h
@@ -46,7 +46,7 @@ struct ValueMappers
 };
 
 class OpenTelemetrySinkBackend
-    : public boost::log::sinks::basic_sink_backend<boost::log::sinks::synchronized_feeding>
+    : public boost::log::sinks::basic_sink_backend<boost::log::sinks::concurrent_feeding>
 {
 public:
   static const std::string &libraryVersion()

--- a/instrumentation/boost_log/opentelemetry_boost_log_sink-config.cmake.in
+++ b/instrumentation/boost_log/opentelemetry_boost_log_sink-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-target.cmake")
+
+check_required_components(@PROJECT_NAME@)

--- a/instrumentation/boost_log/src/sink.cc
+++ b/instrumentation/boost_log/src/sink.cc
@@ -1,0 +1,145 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <opentelemetry/instrumentation/boost_log/sink.h>
+
+#include <opentelemetry/logs/provider.h>
+#include <opentelemetry/trace/semantic_conventions.h>
+
+#include <boost/log/attributes/value_extraction.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
+#include <boost/log/utility/type_dispatch/date_time_types.hpp>
+
+namespace opentelemetry
+{
+namespace instrumentation
+{
+namespace boost_log
+{
+
+static bool ToTimestampDefault(const boost::log::record_view &record,
+                               std::chrono::system_clock::time_point &value) noexcept
+{
+  using namespace std::chrono;
+  static constexpr boost::posix_time::ptime kEpochTime(boost::gregorian::date(1970, 1, 1));
+  static constexpr boost::posix_time::ptime kInvalid{};
+
+  const auto &timestamp =
+      boost::log::extract_or_default<boost::posix_time::ptime>(record["TimeStamp"], kInvalid);
+  value = system_clock::time_point(nanoseconds((timestamp - kEpochTime).total_nanoseconds()));
+  return timestamp != kInvalid;
+}
+
+static bool ToThreadIdDefault(const boost::log::record_view &record, std::string &value) noexcept
+{
+  static constexpr boost::log::aux::thread::id kInvalid{};
+
+  const auto &thread_id =
+      boost::log::extract_or_default<boost::log::aux::thread::id>(record["ThreadID"], kInvalid);
+
+  std::stringstream ss;
+  ss << thread_id;
+  value = ss.str();
+  return thread_id != kInvalid;
+}
+
+static bool ToFileNameDefault(const boost::log::record_view &record, std::string &value) noexcept
+{
+  value = boost::log::extract_or_default<std::string>(record["FileName"], std::string{});
+  return !value.empty();
+}
+
+static bool ToFuncNameDefault(const boost::log::record_view &record, std::string &value) noexcept
+{
+  value = boost::log::extract_or_default<std::string>(record["FunctionName"], std::string{});
+  return !value.empty();
+}
+
+static bool ToLineNumberDefault(const boost::log::record_view &record, int &value) noexcept
+{
+  static constexpr int kInvalid = -1;
+  value = boost::log::extract_or_default<int>(record["LineNumber"], kInvalid);
+  return value != kInvalid;
+}
+
+OpenTelemetrySinkBackend::OpenTelemetrySinkBackend(const ValueMappers &mappers) noexcept
+{
+  mappers_.ToSeverity =
+      mappers.ToSeverity ? mappers.ToSeverity : [](const boost::log::record_view &record) {
+        return levelToSeverity(boost::log::extract_or_default<int>(record["Severity"], -1));
+      };
+  mappers_.ToTimeStamp = mappers.ToTimeStamp ? mappers.ToTimeStamp : ToTimestampDefault;
+  mappers_.ToThreadId  = mappers.ToThreadId ? mappers.ToThreadId : ToThreadIdDefault;
+  mappers_.ToCodeFile  = mappers.ToCodeFile ? mappers.ToCodeFile : ToFileNameDefault;
+  mappers_.ToCodeFunc  = mappers.ToCodeFunc ? mappers.ToCodeFunc : ToFuncNameDefault;
+  mappers_.ToCodeLine  = mappers.ToCodeLine ? mappers.ToCodeLine : ToLineNumberDefault;
+
+  using namespace opentelemetry::trace::SemanticConventions;
+  using opentelemetry::logs::LogRecord;
+  using timestamp_t = std::chrono::system_clock::time_point;
+
+  set_timestamp_if_valid_ = {[](LogRecord *, const timestamp_t &) {},
+                             [](LogRecord *log_record, const timestamp_t &timestamp) {
+                               log_record->SetTimestamp(timestamp);
+                             }};
+
+  set_thread_id_if_valid_ = {[](LogRecord *, const std::string &) {},
+                             [](LogRecord *log_record, const std::string &thread_id) {
+                               log_record->SetAttribute(kThreadId, thread_id);
+                             }};
+
+  set_file_path_if_valid_ = {[](LogRecord *, const std::string &) {},
+                             [](LogRecord *log_record, const std::string &file_name) {
+                               log_record->SetAttribute(kCodeFilepath, file_name);
+                             }};
+
+  set_func_name_if_valid_ = {[](LogRecord *, const std::string &) {},
+                             [](LogRecord *log_record, const std::string &func_name) {
+                               log_record->SetAttribute(kCodeFunction, func_name);
+                             }};
+
+  set_code_line_if_valid_ = {[](LogRecord *, int) {},
+                             [](LogRecord *log_record, int code_line) {
+                               log_record->SetAttribute(kCodeLineno, code_line);
+                             }};
+}
+
+void OpenTelemetrySinkBackend::consume(const boost::log::record_view &record)
+{
+  static constexpr auto kLoggerName  = "Boost logger";
+  static constexpr auto kLibraryName = "Boost.Log";
+
+  auto provider   = opentelemetry::logs::Provider::GetLoggerProvider();
+  auto logger     = provider->GetLogger(kLoggerName, kLibraryName, libraryVersion());
+  auto log_record = logger->CreateLogRecord();
+
+  if (log_record)
+  {
+    log_record->SetBody(
+        boost::log::extract_or_default<std::string>(record["Message"], std::string{}));
+    log_record->SetSeverity(mappers_.ToSeverity(record));
+
+    std::chrono::system_clock::time_point timestamp;
+    set_timestamp_if_valid_[mappers_.ToTimeStamp(record, timestamp)](log_record.get(), timestamp);
+
+    std::string thread_id;
+    set_thread_id_if_valid_[mappers_.ToThreadId(record, thread_id)](log_record.get(), thread_id);
+
+    std::string file_name;
+    set_file_path_if_valid_[mappers_.ToCodeFile(record, file_name)](log_record.get(), file_name);
+
+    std::string func_name;
+    set_func_name_if_valid_[mappers_.ToCodeFunc(record, func_name)](log_record.get(), func_name);
+
+    int code_line;
+    set_code_line_if_valid_[mappers_.ToCodeLine(record, code_line)](log_record.get(), code_line);
+
+    logger->EmitLogRecord(std::move(log_record));
+  }
+}
+
+}  // namespace boost_log
+}  // namespace instrumentation
+}  // namespace opentelemetry

--- a/instrumentation/boost_log/test/sink_test.cc
+++ b/instrumentation/boost_log/test/sink_test.cc
@@ -1,0 +1,498 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <opentelemetry/instrumentation/boost_log/sink.h>
+
+#include <opentelemetry/logs/logger.h>
+#include <opentelemetry/logs/logger_provider.h>
+#include <opentelemetry/logs/provider.h>
+
+#include <opentelemetry/exporters/ostream/log_record_exporter_factory.h>
+#include <opentelemetry/sdk/logs/exporter.h>
+#include <opentelemetry/sdk/logs/logger_provider_factory.h>
+#include <opentelemetry/sdk/logs/processor.h>
+#include <opentelemetry/sdk/logs/simple_log_record_processor_factory.h>
+
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sources/logger.hpp>
+#include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
+#include <boost/smart_ptr/make_shared_object.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace common    = opentelemetry::common;
+namespace instr     = opentelemetry::instrumentation;
+namespace nostd     = opentelemetry::nostd;
+namespace logs_api  = opentelemetry::logs;
+namespace trace_api = opentelemetry::trace;
+
+namespace logging = boost::log;
+namespace sinks   = boost::log::sinks;
+namespace src     = boost::log::sources;
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::SaveArg;
+
+struct LogRecordMock final : public logs_api::LogRecord
+{
+  MOCK_METHOD(void, SetTimestamp, (common::SystemTimestamp), (noexcept, override));
+  MOCK_METHOD(void, SetObservedTimestamp, (common::SystemTimestamp), (noexcept, override));
+  MOCK_METHOD(void, SetSeverity, (logs_api::Severity), (noexcept, override));
+  MOCK_METHOD(void, SetBody, (const common::AttributeValue &), (noexcept, override));
+  MOCK_METHOD(void,
+              SetAttribute,
+              (nostd::string_view, const common::AttributeValue &),
+              (noexcept, override));
+  MOCK_METHOD(void, SetEventId, (int64_t, nostd::string_view), (noexcept, override));
+  MOCK_METHOD(void, SetTraceId, (const trace_api::TraceId &), (noexcept, override));
+  MOCK_METHOD(void, SetSpanId, (const trace_api::SpanId &), (noexcept, override));
+  MOCK_METHOD(void, SetTraceFlags, (const trace_api::TraceFlags &), (noexcept, override));
+};
+
+struct LoggerMock final : public logs_api::Logger
+{
+  MOCK_METHOD(const nostd::string_view, GetName, (), (noexcept, override));
+  MOCK_METHOD(nostd::unique_ptr<logs_api::LogRecord>, CreateLogRecord, (), (noexcept, override));
+  MOCK_METHOD(void,
+              EmitLogRecord,
+              (nostd::unique_ptr<logs_api::LogRecord> &&),
+              (noexcept, override));
+};
+
+struct LoggerProviderMock final : public logs_api::LoggerProvider
+{
+  MOCK_METHOD(nostd::shared_ptr<logs_api::Logger>,
+              GetLogger,
+              (nostd::string_view,
+               nostd::string_view,
+               nostd::string_view,
+               nostd::string_view,
+               const common::KeyValueIterable &),
+              (override));
+};
+
+class OpenTelemetrySinkTest : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    using opentelemetry::instrumentation::boost_log::OpenTelemetrySinkBackend;
+    auto backend = boost::make_shared<OpenTelemetrySinkBackend>();
+    auto sink    = boost::make_shared<sinks::synchronous_sink<OpenTelemetrySinkBackend>>(backend);
+    logging::core::get()->add_sink(sink);
+    logging::add_common_attributes();
+  }
+
+  void TearDown() override { logging::core::get()->remove_all_sinks(); }
+};
+
+TEST_F(OpenTelemetrySinkTest, LevelToSeverity)
+{
+  namespace Level = logging::trivial;
+  using logs_api::Severity;
+  using ots = instr::boost_log::OpenTelemetrySinkBackend;
+
+  ASSERT_TRUE(Severity::kFatal == ots::levelToSeverity(Level::fatal));
+  ASSERT_TRUE(Severity::kError == ots::levelToSeverity(Level::error));
+  ASSERT_TRUE(Severity::kWarn == ots::levelToSeverity(Level::warning));
+  ASSERT_TRUE(Severity::kInfo == ots::levelToSeverity(Level::info));
+  ASSERT_TRUE(Severity::kDebug == ots::levelToSeverity(Level::debug));
+  ASSERT_TRUE(Severity::kTrace == ots::levelToSeverity(Level::trace));
+  ASSERT_TRUE(Severity::kInvalid == ots::levelToSeverity(std::numeric_limits<int>::lowest()));
+  ASSERT_TRUE(Severity::kInvalid == ots::levelToSeverity(std::numeric_limits<int>::lowest() + 1));
+  ASSERT_TRUE(Severity::kInvalid == ots::levelToSeverity(-42));
+  ASSERT_TRUE(Severity::kTrace == ots::levelToSeverity(0));
+  ASSERT_TRUE(Severity::kInvalid == ots::levelToSeverity(42));
+  ASSERT_TRUE(Severity::kInvalid == ots::levelToSeverity(std::numeric_limits<int>::max() - 1));
+  ASSERT_TRUE(Severity::kInvalid == ots::levelToSeverity(std::numeric_limits<int>::max()));
+}
+
+TEST_F(OpenTelemetrySinkTest, Log_Success)
+{
+  auto provider_mock = new LoggerProviderMock();
+  logs_api::Provider::SetLoggerProvider(nostd::shared_ptr<logs_api::LoggerProvider>(provider_mock));
+  auto logger_mock    = new LoggerMock();
+  auto logger_ptr     = nostd::shared_ptr<logs_api::Logger>(logger_mock);
+  auto logrecord_mock = new LogRecordMock();
+  auto logrecord_ptr  = nostd::unique_ptr<logs_api::LogRecord>(logrecord_mock);
+
+  nostd::string_view logger_name;
+  nostd::string_view library_name;
+  nostd::string_view library_version;
+  logs_api::Severity severity = {};
+  common::AttributeValue message;
+  common::SystemTimestamp timestamp;
+  common::AttributeValue line_number;
+  common::AttributeValue file_name;
+  common::AttributeValue func_name;
+  common::AttributeValue thread_id;
+
+  src::severity_logger<int> logger;
+  auto pre_log = std::chrono::system_clock::now();
+  EXPECT_CALL(*provider_mock, GetLogger(_, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<0>(&logger_name), SaveArg<1>(&library_name),
+                      SaveArg<2>(&library_version), Return(logger_ptr)));
+  EXPECT_CALL(*logger_mock, CreateLogRecord()).WillOnce(Return(std::move(logrecord_ptr)));
+  EXPECT_CALL(*logrecord_mock, SetSeverity(_)).WillOnce(SaveArg<0>(&severity));
+  EXPECT_CALL(*logrecord_mock, SetBody(_)).WillOnce(SaveArg<0>(&message));
+  EXPECT_CALL(*logrecord_mock, SetTimestamp(_)).WillOnce(SaveArg<0>(&timestamp));
+  EXPECT_CALL(*logrecord_mock, SetAttribute(nostd::string_view("code.lineno"), _))
+      .WillOnce(SaveArg<1>(&line_number));
+  EXPECT_CALL(*logrecord_mock, SetAttribute(nostd::string_view("code.filepath"), _))
+      .WillOnce(SaveArg<1>(&file_name));
+  EXPECT_CALL(*logrecord_mock, SetAttribute(nostd::string_view("code.function"), _))
+      .WillOnce(SaveArg<1>(&func_name));
+  EXPECT_CALL(*logrecord_mock, SetAttribute(nostd::string_view("thread.id"), _))
+      .WillOnce(SaveArg<1>(&thread_id));
+  EXPECT_CALL(*logger_mock, EmitLogRecord(_)).Times(1);
+
+  BOOST_LOG_SEV(logger, logging::trivial::info)
+      << boost::log::add_value("FileName", __FILE__)
+      << boost::log::add_value("FunctionName", __FUNCTION__)
+      << boost::log::add_value("LineNumber", int{__LINE__}) << "test message";
+  auto post_log = std::chrono::system_clock::now();
+  ASSERT_EQ(logger_name, "Boost logger");
+  ASSERT_EQ(library_name, "Boost.Log");
+  ASSERT_EQ(library_version, instr::boost_log::OpenTelemetrySinkBackend::libraryVersion());
+  ASSERT_TRUE(nostd::holds_alternative<nostd::string_view>(message));
+  ASSERT_EQ(nostd::get<nostd::string_view>(message), "test message");
+  ASSERT_TRUE(severity == logs_api::Severity::kInfo);
+  ASSERT_TRUE(timestamp.time_since_epoch() >= pre_log.time_since_epoch());
+  ASSERT_TRUE(timestamp.time_since_epoch() <= post_log.time_since_epoch());
+  ASSERT_TRUE(nostd::holds_alternative<nostd::string_view>(file_name));
+  ASSERT_TRUE(std::string(nostd::get<nostd::string_view>(file_name)).find("sink_test.cc") !=
+              std::string::npos);
+  ASSERT_TRUE(nostd::holds_alternative<nostd::string_view>(func_name));
+  ASSERT_TRUE(std::string(nostd::get<nostd::string_view>(func_name)).find("TestBody") !=
+              std::string::npos);
+  ASSERT_TRUE(nostd::holds_alternative<int>(line_number));
+  ASSERT_GE(nostd::get<int>(line_number), 0);
+  ASSERT_TRUE(nostd::holds_alternative<nostd::string_view>(thread_id));
+  ASSERT_FALSE(nostd::get<nostd::string_view>(thread_id).empty());
+}
+
+TEST_F(OpenTelemetrySinkTest, Log_Failure)
+{
+  auto provider_mock = new LoggerProviderMock();
+  logs_api::Provider::SetLoggerProvider(nostd::shared_ptr<logs_api::LoggerProvider>(provider_mock));
+  auto logger_mock = new LoggerMock();
+  auto logger_ptr  = nostd::shared_ptr<logs_api::Logger>(logger_mock);
+
+  nostd::string_view logger_name;
+  nostd::string_view library_name;
+  nostd::string_view library_version;
+
+  src::severity_logger<int> logger;
+  EXPECT_CALL(*provider_mock, GetLogger(_, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<0>(&logger_name), SaveArg<1>(&library_name),
+                      SaveArg<2>(&library_version), Return(logger_ptr)));
+  EXPECT_CALL(*logger_mock, CreateLogRecord()).WillOnce(Return(nullptr));
+  EXPECT_CALL(*logger_mock, EmitLogRecord(_)).Times(0);
+
+  BOOST_LOG_SEV(logger, logging::trivial::info) << "test message";
+  ASSERT_EQ(logger_name, "Boost logger");
+  ASSERT_EQ(library_name, "Boost.Log");
+  ASSERT_EQ(library_version, instr::boost_log::OpenTelemetrySinkBackend::libraryVersion());
+}
+
+TEST_F(OpenTelemetrySinkTest, Log_WithoutSeverity)
+{
+  auto provider_mock = new LoggerProviderMock();
+  logs_api::Provider::SetLoggerProvider(nostd::shared_ptr<logs_api::LoggerProvider>(provider_mock));
+  auto logger_mock    = new LoggerMock();
+  auto logger_ptr     = nostd::shared_ptr<logs_api::Logger>(logger_mock);
+  auto logrecord_mock = new LogRecordMock();
+  auto logrecord_ptr  = nostd::unique_ptr<logs_api::LogRecord>(logrecord_mock);
+
+  nostd::string_view logger_name;
+  nostd::string_view library_name;
+  nostd::string_view library_version;
+  logs_api::Severity severity = {};
+  common::AttributeValue message;
+  common::SystemTimestamp timestamp;
+
+  src::logger logger;
+  auto pre_log = std::chrono::system_clock::now();
+  EXPECT_CALL(*provider_mock, GetLogger(_, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<0>(&logger_name), SaveArg<1>(&library_name),
+                      SaveArg<2>(&library_version), Return(logger_ptr)));
+  EXPECT_CALL(*logger_mock, CreateLogRecord()).WillOnce(Return(std::move(logrecord_ptr)));
+  EXPECT_CALL(*logrecord_mock, SetSeverity(_)).WillOnce(SaveArg<0>(&severity));
+  EXPECT_CALL(*logrecord_mock, SetBody(_)).WillOnce(SaveArg<0>(&message));
+  EXPECT_CALL(*logrecord_mock, SetTimestamp(_)).WillOnce(SaveArg<0>(&timestamp));
+  EXPECT_CALL(*logrecord_mock, SetAttribute(nostd::string_view("thread.id"), _)).Times(1);
+  EXPECT_CALL(*logger_mock, EmitLogRecord(_)).Times(1);
+
+  BOOST_LOG(logger) << "no severity";
+  auto post_log = std::chrono::system_clock::now();
+  ASSERT_EQ(logger_name, "Boost logger");
+  ASSERT_EQ(library_name, "Boost.Log");
+  ASSERT_EQ(library_version, instr::boost_log::OpenTelemetrySinkBackend::libraryVersion());
+  ASSERT_TRUE(nostd::holds_alternative<nostd::string_view>(message));
+  ASSERT_EQ(std::string(nostd::get<nostd::string_view>(message)), "no severity");
+  ASSERT_TRUE(severity == logs_api::Severity::kInvalid);
+  ASSERT_TRUE(timestamp.time_since_epoch() >= pre_log.time_since_epoch());
+  ASSERT_TRUE(timestamp.time_since_epoch() <= post_log.time_since_epoch());
+}
+
+TEST_F(OpenTelemetrySinkTest, Multi_Threaded)
+{
+  namespace logs_sdk = opentelemetry::sdk::logs;
+  namespace logs_exp = opentelemetry::exporter::logs;
+
+  // Set up logger provider
+  auto exporter     = logs_exp::OStreamLogRecordExporterFactory::Create();
+  auto processor    = logs_sdk::SimpleLogRecordProcessorFactory::Create(std::move(exporter));
+  auto provider     = logs_sdk::LoggerProviderFactory::Create(std::move(processor));
+  auto provider_ptr = nostd::shared_ptr<logs_api::LoggerProvider>(provider.release());
+  logs_api::Provider::SetLoggerProvider(provider_ptr);
+  // Save original stream buffer, then redirect cout to our new stream buffer
+  std::streambuf *original = std::cout.rdbuf();
+  std::stringstream output;
+  std::cout.rdbuf(output.rdbuf());
+  // Set up logging threads
+  const auto count = 100UL;
+  std::vector<std::thread> threads;
+  threads.reserve(count);
+
+  src::severity_logger<int> logger;
+  const auto pre_log = std::chrono::system_clock::now().time_since_epoch().count();
+
+  for (size_t index = 0; index < count; ++index)
+  {
+    threads.emplace_back([&logger, index]() {
+      BOOST_LOG_SEV(logger, logging::trivial::info) << "Test message " << index;
+    });
+  }
+
+  for (auto &task : threads)
+  {
+    if (task.joinable())
+    {
+      task.join();
+    }
+  }
+
+  const auto post_log = std::chrono::system_clock::now().time_since_epoch().count();
+
+  // Reset cout's original stringstream buffer
+  std::cout.rdbuf(original);
+  // Extract messages with timestamps
+  const auto field_name_length = 23UL;
+  std::vector<std::string> messages;
+  std::vector<uint64_t> timestamps;
+  std::string str;
+
+  while (std::getline(output, str, '\n'))
+  {
+    if (str.find(" timestamp          : ") != std::string::npos)
+    {
+      timestamps.push_back(std::strtoul(str.substr(field_name_length).c_str(), nullptr, 10));
+    }
+    else if (str.find(" body               : ") != std::string::npos)
+    {
+      messages.push_back(str.substr(field_name_length));
+    }
+  }
+
+  for (size_t index = 0; index < count; ++index)
+  {
+    const auto &message = "Test message " + std::to_string(index);
+    const auto &entry   = std::find(messages.begin(), messages.end(), message);
+    ASSERT_TRUE(entry != messages.end()) << message;
+
+    const auto offset = std::distance(messages.begin(), entry);
+    ASSERT_GE(timestamps[offset], pre_log);
+    ASSERT_LE(timestamps[offset], post_log);
+  }
+}
+
+void SetUpBackendWithDummyMappers()
+{
+  opentelemetry::instrumentation::boost_log::ValueMappers mappers;
+  mappers.ToSeverity = [](const boost::log::record_view &) {
+    return opentelemetry::logs::Severity::kTrace4;
+  };
+  mappers.ToTimeStamp = [](const boost::log::record_view &,
+                           std::chrono::system_clock::time_point &) {
+    // This should prevent SetTimestamp attribute from being called entirely
+    return false;
+  };
+  mappers.ToCodeLine = [](const boost::log::record_view &, int &code_line) {
+    code_line = 42;
+    return true;
+  };
+  mappers.ToCodeFunc = [](const boost::log::record_view &, std::string &func_name) {
+    func_name = "doFoo";
+    return true;
+  };
+  mappers.ToCodeFile = [](const boost::log::record_view &, std::string &file_name) {
+    file_name = "bar.cpp";
+    return true;
+  };
+  mappers.ToThreadId = [](const boost::log::record_view &, std::string &thread_id) {
+    thread_id = "0x600df457c0d3";
+    return true;
+  };
+
+  using opentelemetry::instrumentation::boost_log::OpenTelemetrySinkBackend;
+  auto backend = boost::make_shared<OpenTelemetrySinkBackend>(mappers);
+  auto sink    = boost::make_shared<sinks::synchronous_sink<OpenTelemetrySinkBackend>>(backend);
+  logging::core::get()->add_sink(sink);
+}
+
+TEST(OpenTelemetrySinkTestSuite, CustomMappers)
+{
+  auto provider_mock = new LoggerProviderMock();
+  logs_api::Provider::SetLoggerProvider(nostd::shared_ptr<logs_api::LoggerProvider>(provider_mock));
+  auto logger_mock    = new LoggerMock();
+  auto logger_ptr     = nostd::shared_ptr<logs_api::Logger>(logger_mock);
+  auto logrecord_mock = new LogRecordMock();
+  auto logrecord_ptr  = nostd::unique_ptr<logs_api::LogRecord>(logrecord_mock);
+
+  nostd::string_view logger_name;
+  nostd::string_view library_name;
+  nostd::string_view library_version;
+  logs_api::Severity severity = {};
+  common::AttributeValue message;
+  common::AttributeValue line_number;
+  common::AttributeValue file_name;
+  common::AttributeValue func_name;
+  common::AttributeValue thread_id;
+
+  SetUpBackendWithDummyMappers();
+  src::severity_logger<int> logger;
+
+  EXPECT_CALL(*provider_mock, GetLogger(_, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<0>(&logger_name), SaveArg<1>(&library_name),
+                      SaveArg<2>(&library_version), Return(logger_ptr)));
+  EXPECT_CALL(*logger_mock, CreateLogRecord()).WillOnce(Return(std::move(logrecord_ptr)));
+  EXPECT_CALL(*logrecord_mock, SetSeverity(_)).WillOnce(SaveArg<0>(&severity));
+  EXPECT_CALL(*logrecord_mock, SetBody(_)).WillOnce(SaveArg<0>(&message));
+  EXPECT_CALL(*logrecord_mock, SetTimestamp(_)).Times(0);
+  EXPECT_CALL(*logrecord_mock, SetAttribute(nostd::string_view("code.lineno"), _))
+      .WillOnce(SaveArg<1>(&line_number));
+  EXPECT_CALL(*logrecord_mock, SetAttribute(nostd::string_view("code.filepath"), _))
+      .WillOnce(SaveArg<1>(&file_name));
+  EXPECT_CALL(*logrecord_mock, SetAttribute(nostd::string_view("code.function"), _))
+      .WillOnce(SaveArg<1>(&func_name));
+  EXPECT_CALL(*logrecord_mock, SetAttribute(nostd::string_view("thread.id"), _))
+      .WillOnce(SaveArg<1>(&thread_id));
+  EXPECT_CALL(*logger_mock, EmitLogRecord(_)).Times(1);
+
+  BOOST_LOG(logger) << "custom mappers";
+  ASSERT_EQ(logger_name, "Boost logger");
+  ASSERT_EQ(library_name, "Boost.Log");
+  ASSERT_EQ(library_version, instr::boost_log::OpenTelemetrySinkBackend::libraryVersion());
+  ASSERT_TRUE(nostd::holds_alternative<nostd::string_view>(message));
+  ASSERT_EQ(nostd::get<nostd::string_view>(message), "custom mappers");
+  ASSERT_TRUE(severity == logs_api::Severity::kTrace4);
+  ASSERT_TRUE(nostd::holds_alternative<nostd::string_view>(file_name));
+  ASSERT_TRUE(std::string(nostd::get<nostd::string_view>(file_name)).find("bar.cpp") == 0);
+  ASSERT_TRUE(nostd::holds_alternative<nostd::string_view>(func_name));
+  ASSERT_TRUE(std::string(nostd::get<nostd::string_view>(func_name)).find("doFoo") == 0);
+  ASSERT_TRUE(nostd::holds_alternative<int>(line_number));
+  ASSERT_EQ(nostd::get<int>(line_number), 42);
+  ASSERT_TRUE(nostd::holds_alternative<nostd::string_view>(thread_id));
+  ASSERT_TRUE(std::string(nostd::get<nostd::string_view>(thread_id)).find("0x600df457c0d3") == 0);
+  logging::core::get()->remove_all_sinks();
+}
+
+enum class CustomSeverity
+{
+  kRed,
+  kOrange,
+  kYellow,
+  kGreen,
+  kBlue,
+  kIndigo,
+  kViolet
+};
+
+class CustomSeverityTest
+    : public ::testing::TestWithParam<std::tuple<CustomSeverity, opentelemetry::logs::Severity>>
+{
+protected:
+  void SetUp() override
+  {
+    opentelemetry::instrumentation::boost_log::ValueMappers mappers;
+    mappers.ToSeverity = [](const boost::log::record_view &record) {
+      if (const auto &result = boost::log::extract<CustomSeverity>(record["Severity"]))
+      {
+        switch (result.get())
+        {
+          using opentelemetry::logs::Severity;
+
+          case CustomSeverity::kRed:
+            return Severity::kFatal;
+          case CustomSeverity::kOrange:
+            return Severity::kError;
+          case CustomSeverity::kYellow:
+            return Severity::kWarn;
+          case CustomSeverity::kGreen:
+            return Severity::kInfo;
+          case CustomSeverity::kBlue:
+            return Severity::kDebug;
+          case CustomSeverity::kIndigo:
+            return Severity::kTrace;
+          default:
+            return Severity::kInvalid;
+        }
+      }
+
+      return opentelemetry::logs::Severity::kInvalid;
+    };
+
+    using opentelemetry::instrumentation::boost_log::OpenTelemetrySinkBackend;
+    auto backend = boost::make_shared<OpenTelemetrySinkBackend>(mappers);
+    auto sink    = boost::make_shared<sinks::synchronous_sink<OpenTelemetrySinkBackend>>(backend);
+    logging::core::get()->add_sink(sink);
+  }
+
+  void TearDown() override { logging::core::get()->remove_all_sinks(); }
+};
+
+TEST_P(CustomSeverityTest, LevelMapping)
+{
+  const auto input_level    = std::get<0>(GetParam());
+  const auto expected_level = std::get<1>(GetParam());
+
+  auto provider_mock = new LoggerProviderMock();
+  logs_api::Provider::SetLoggerProvider(nostd::shared_ptr<logs_api::LoggerProvider>(provider_mock));
+  auto logger_mock    = new LoggerMock();
+  auto logger_ptr     = nostd::shared_ptr<logs_api::Logger>(logger_mock);
+  auto logrecord_mock = new LogRecordMock();
+  auto logrecord_ptr  = nostd::unique_ptr<logs_api::LogRecord>(logrecord_mock);
+
+  logs_api::Severity severity = {};
+
+  EXPECT_CALL(*provider_mock, GetLogger(_, _, _, _, _)).WillOnce(Return(logger_ptr));
+  EXPECT_CALL(*logger_mock, CreateLogRecord()).WillOnce(Return(std::move(logrecord_ptr)));
+  EXPECT_CALL(*logrecord_mock, SetSeverity(_)).WillOnce(SaveArg<0>(&severity));
+  EXPECT_CALL(*logrecord_mock, SetTimestamp(_)).Times(1);
+  EXPECT_CALL(*logrecord_mock, SetAttribute(nostd::string_view("thread.id"), _)).Times(1);
+  EXPECT_CALL(*logrecord_mock, SetBody(_)).Times(1);
+  EXPECT_CALL(*logger_mock, EmitLogRecord(_)).Times(1);
+
+  src::severity_logger<CustomSeverity> logger;
+  BOOST_LOG_SEV(logger, input_level);
+  ASSERT_TRUE(severity == expected_level);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    OpenTelemetrySinkTestSuite,
+    CustomSeverityTest,
+    ::testing::Values(
+        std::make_tuple(CustomSeverity::kRed, opentelemetry::logs::Severity::kFatal),
+        std::make_tuple(CustomSeverity::kOrange, opentelemetry::logs::Severity::kError),
+        std::make_tuple(CustomSeverity::kYellow, opentelemetry::logs::Severity::kWarn),
+        std::make_tuple(CustomSeverity::kGreen, opentelemetry::logs::Severity::kInfo),
+        std::make_tuple(CustomSeverity::kBlue, opentelemetry::logs::Severity::kDebug),
+        std::make_tuple(CustomSeverity::kIndigo, opentelemetry::logs::Severity::kTrace),
+        std::make_tuple(CustomSeverity::kViolet, opentelemetry::logs::Severity::kInvalid)));


### PR DESCRIPTION
Implemented as described in https://github.com/open-telemetry/opentelemetry-cpp/issues/2048:

- Sink backend allows for mapping customizations to account for the extensive flexibility that boost sinks already provide.
- Minimal examples provided to demonstrate the setup required.
- Basic unit testing.
- Tried using the same flags as those used in otel-cpp for configuring cmake project.
- Add clang format file to help keep the style in line with otel-cpp repo.