### PR TITLE
[Geneva] Remove curl dependence for Geneva exporter on Linux

### DIFF
--- a/exporters/geneva/CMakeLists.txt
+++ b/exporters/geneva/CMakeLists.txt
@@ -15,11 +15,6 @@ if(OTELCPP_VERSIONED_LIBS AND NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "OTELCPP_VERSIONED_LIBS=ON requires BUILD_SHARED_LIBS=ON")
 endif()
     
-
-if(NOT WIN32)
-  find_package(CURL REQUIRED)
-endif()
-
 add_definitions(-DHAVE_CONSOLE_LOG)
 if(MAIN_PROJECT)
   find_package(opentelemetry-cpp REQUIRED)


### PR DESCRIPTION
cURL is not used in Geneva exporter and should be removed.