### PR TITLE
Consistent naming of Geneva exporter with logs and trace for Windows and Linux

### DIFF
--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -57,49 +57,49 @@ endif()
 include_directories(include)
 
 # create fluentd trace exporter
-add_library(opentelemetry_exporter_fluentd_trace src/trace/fluentd_exporter.cc
-                                                 src/trace/recordable.cc)
+add_library(opentelemetry_exporter_geneva_trace src/trace/fluentd_exporter.cc
+                                                src/trace/recordable.cc)
 if(MAIN_PROJECT)
-  target_include_directories(opentelemetry_exporter_fluentd_trace
+  target_include_directories(opentelemetry_exporter_geneva_trace
                            PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS})
   target_link_libraries(
-    opentelemetry_exporter_fluentd_trace
+    opentelemetry_exporter_geneva_trace
     PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES}
     INTERFACE nlohmann_json::nlohmann_json)
-  set_target_properties(opentelemetry_exporter_fluentd_trace
+  set_target_properties(opentelemetry_exporter_geneva_trace
                         PROPERTIES EXPORT_NAME trace)
 else()
   target_link_libraries(
-    opentelemetry_exporter_fluentd_trace
+    opentelemetry_exporter_geneva_trace
     PUBLIC opentelemetry_trace opentelemetry_resources opentelemetry_common
     INTERFACE nlohmann_json::nlohmann_json)
 endif()
 
 # create fluentd logs exporter
 
-add_library(opentelemetry_exporter_fluentd_logs src/log/fluentd_exporter.cc
-                                                src/log/recordable.cc)
+add_library(opentelemetry_exporter_geneva_logs src/log/fluentd_exporter.cc
+                                               src/log/recordable.cc)
 if(MAIN_PROJECT)
-  target_include_directories(opentelemetry_exporter_fluentd_logs
+  target_include_directories(opentelemetry_exporter_geneva_logs
                            PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS})
   target_link_libraries(
-    opentelemetry_exporter_fluentd_logs
+    opentelemetry_exporter_geneva_logs
     PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES}
     INTERFACE nlohmann_json::nlohmann_json)
 
-  set_target_properties(opentelemetry_exporter_fluentd_logs
+  set_target_properties(opentelemetry_exporter_geneva_logs
                         PROPERTIES EXPORT_NAME logs)
 else()
     target_link_libraries(
-      opentelemetry_exporter_fluentd_logs
+      opentelemetry_exporter_geneva_logs
       PUBLIC opentelemetry_logs opentelemetry_resources opentelemetry_common
       INTERFACE nlohmann_json::nlohmann_json)
 endif()
 
 if(nlohmann_json_clone)
-  add_dependencies(opentelemetry_exporter_fluentd_trace
+  add_dependencies(opentelemetry_exporter_geneva_logs
                    nlohmann_json::nlohmann_json)
-  add_dependencies(opentelemetry_exporter_fluentd_logs
+  add_dependencies(opentelemetry_exporter_geneva_logs
                    nlohmann_json::nlohmann_json)
   include_directories(${PROJECT_BINARY_DIR}/include)
 endif()
@@ -114,14 +114,8 @@ endif()
 
 if(OPENTELEMETRY_INSTALL)
   install(
-    TARGETS opentelemetry_exporter_fluentd_trace
-    EXPORT "${PROJECT_NAME}-target"
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
-  install(
-    TARGETS opentelemetry_exporter_fluentd_logs
+    TARGETS opentelemetry_exporter_geneva_logs
+            opentelemetry_exporter_geneva_trace
     EXPORT "${PROJECT_NAME}-target"
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -149,7 +143,7 @@ if(BUILD_TESTING)
     opentelemetry_common
     opentelemetry_trace
     opentelemetry_resources
-    opentelemetry_exporter_fluentd_trace)
+    opentelemetry_exporter_geneva_trace)
 
   if(nlohmann_json_clone)
     add_dependencies(fluentd_recordable_trace_test nlohmann_json::nlohmann_json)
@@ -172,7 +166,7 @@ if(BUILD_TESTING)
     opentelemetry_common
     opentelemetry_logs
     opentelemetry_resources
-    opentelemetry_exporter_fluentd_logs)
+    opentelemetry_exporter_geneva_logs)
 
   if(nlohmann_json_clone)
     add_dependencies(fluentd_recordable_logs_test nlohmann_json::nlohmann_json)

--- a/exporters/geneva-trace/CMakeLists.txt
+++ b/exporters/geneva-trace/CMakeLists.txt
@@ -12,9 +12,15 @@ if(MAIN_PROJECT)
   option(WITH_EXAMPLES "Build examples" ON)
 endif()
 
-add_library(opentelemetry-cpp-geneva-trace-log-exporter INTERFACE)
+add_library(opentelemetry_exporter_geneva_trace INTERFACE)
 target_include_directories(
-  opentelemetry-cpp-geneva-trace-log-exporter INTERFACE
+  opentelemetry_exporter_geneva_trace INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+
+add_library(opentelemetry_exporter_geneva_logs INTERFACE)
+target_include_directories(
+  opentelemetry_exporter_geneva_logs INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
@@ -27,7 +33,7 @@ if(OPENTELEMETRY_INSTALL)
   install(DIRECTORY include/ DESTINATION include)
 
   install(
-    TARGETS opentelemetry-cpp-geneva-trace-log-exporter
+    TARGETS opentelemetry_exporter_geneva_trace opentelemetry_exporter_geneva_logs
     EXPORT "${PROJECT_NAME}-target")
 
   if(NOT MAIN_PROJECT)


### PR DESCRIPTION
This PR makes the cmake target consistent between Windows and Linux for Geneva exporter, so the same target name like `opentelemetry_exporter_geneva_trace` will work cross platforms.