### PR TITLE
Remove v1 namespace usage to permit use of ABI v2

### DIFF
--- a/exporters/fluentd/include/opentelemetry/exporters/fluentd/common/fluentd_common.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/fluentd/common/fluentd_common.h
@@ -116,8 +116,8 @@ inline std::string AttributeValueToString(
     result = std::to_string(nostd::get<double>(value));
   } else if (nostd::holds_alternative<const char*>(value)) {
     result = std::string(nostd::get<const char*>(value));
-  } else if (nostd::holds_alternative<opentelemetry::v1::nostd::string_view>(value)) {
-    result = std::string(nostd::get<opentelemetry::v1::nostd::string_view>(value).data());
+  } else if (nostd::holds_alternative<opentelemetry::nostd::string_view>(value)) {
+    result = std::string(nostd::get<opentelemetry::nostd::string_view>(value).data());
   } else {
     LOG_WARN("[Fluentd Exporter] AttributeValueToString - "
              " Nested attributes not supported - ignored");

--- a/exporters/user_events/src/metrics_exporter.cc
+++ b/exporters/user_events/src/metrics_exporter.cc
@@ -65,7 +65,7 @@ sdk_common::ExportResult Exporter::Export(
     return sdk_common::ExportResult::kSuccess;
   }
 
-  proto::collector::metrics::v1::ExportMetricsServiceRequest request;
+  proto::collector::metrics::ExportMetricsServiceRequest request;
   otlp_exporter::OtlpMetricUtils::PopulateRequest(data, &request);
 
   int size = (int)request.ByteSizeLong();


### PR DESCRIPTION
Remove explicit use of ::v1 in namespaces to support opentelemetry-cpp WITH_ABI_VERSION_2=ON