### PR TITLE
[geneva-exporter] add traceflag override method to fluentd exporter

### DIFF
--- a/exporters/fluentd/include/opentelemetry/exporters/fluentd/trace/recordable.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/fluentd/trace/recordable.h
@@ -71,6 +71,8 @@ public:
       const opentelemetry::sdk::instrumentationscope::InstrumentationScope
           &instrumentation_scope) noexcept override;
 
+  void SetTraceFlags(opentelemetry::trace::TraceFlags flags) noexcept override;
+
 private:
   std::string tag_;
   nlohmann::json events_;

--- a/exporters/fluentd/src/trace/fluentd_exporter.cc
+++ b/exporters/fluentd/src/trace/fluentd_exporter.cc
@@ -60,7 +60,7 @@ FluentdExporter::FluentdExporter()
  */
 std::unique_ptr<sdk::trace::Recordable>
 FluentdExporter::MakeRecordable() noexcept {
-  return std::unique_ptr<sdk::trace::Recordable>(new Recordable);
+  return std::unique_ptr<sdk::trace::Recordable>(new opentelemetry::exporter::fluentd::trace::Recordable());
 }
 
 /**

--- a/exporters/fluentd/src/trace/recordable.cc
+++ b/exporters/fluentd/src/trace/recordable.cc
@@ -148,6 +148,10 @@ void Recordable::SetInstrumentationScope(
       instrumentation_scope.GetVersion();
 }
 
+void Recordable::SetTraceFlags(opentelemetry::trace::TraceFlags flags) noexcept {
+    // TODO: process trace flags
+}
+
 } // namespace trace
 } // namespace fluentd
 } // namespace exporter


### PR DESCRIPTION
Upgrade opentelemtry-proto to 1.1.0 in main repo added `TraceFlags` to `class Recordable`. The fluentd exporter has to override it or it will be an abstract class and cannot be instantiated.

https://github.com/open-telemetry/opentelemetry-cpp/pull/2488