### PR TITLE
[Geneva] update Log class name in geneva_logger_exporter.h

### DIFF
--- a/exporters/fluentd/include/opentelemetry/exporters/geneva/geneva_logger_exporter.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/geneva/geneva_logger_exporter.h
@@ -3,12 +3,11 @@
 
 #pragma once
 
-#define ENABLE_LOGS_PREVIEW
 #include "geneva_exporter_options.h"
 #include <opentelemetry/exporters/fluentd/common/socket_tools.h>
 #include <opentelemetry/exporters/fluentd/log/fluentd_exporter.h>
+#include <opentelemetry/sdk/logs/batch_log_record_processor.h>
 #include <opentelemetry/sdk/logs/logger_provider.h>
-#include <opentelemetry/sdk/logs/batch_log_processor.h>
 #include <opentelemetry/logs/provider.h>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -27,10 +26,10 @@ static inline bool InitializeGenevaExporter( const GenevaExporterOptions options
         opentelemetry::exporter::fluentd::common::FluentdExporterOptions  fluentd_options;
         fluentd_options.retry_count = options.retry_count;
         fluentd_options.endpoint = options.socket_endpoint;
-        auto exporter = std::unique_ptr<opentelemetry::sdk::logs::LogExporter>(
+        auto exporter = std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter>(
             new opentelemetry::exporter::fluentd::logs::FluentdExporter(fluentd_options));
-        auto processor = std::unique_ptr<opentelemetry::sdk::logs::LogProcessor>(
-            new opentelemetry::sdk::logs::BatchLogProcessor(std::move(exporter), options.max_queue_size, options.schedule_delay_millis, options.max_export_batch_size));
+        auto processor = std::unique_ptr<opentelemetry::sdk::logs::LogRecordProcessor>(
+            new opentelemetry::sdk::logs::BatchLogRecordProcessor(std::move(exporter), options.max_queue_size, options.schedule_delay_millis, options.max_export_batch_size));
         auto provider = std::shared_ptr<opentelemetry::logs::LoggerProvider>(
             new opentelemetry::sdk::logs::LoggerProvider(std::move(processor)));
         // Set the global logger provider


### PR DESCRIPTION
Some SDK class names need to be updated like `LogExporter`, etc.