### PR TITLE
Update CMakeLists.txt arguments of Geneva and User Events exporters for Vcpkg build

### DIFF
--- a/.github/workflows/geneva_metrics.yml
+++ b/.github/workflows/geneva_metrics.yml
@@ -43,6 +43,6 @@ jobs:
           mkdir -p "$GITHUB_WORKSPACE/otel_cpp_contrib/exporters/geneva/build"
           cd "$GITHUB_WORKSPACE/otel_cpp_contrib/exporters/geneva/build"
           cmake .. "-DCMAKE_PREFIX_PATH=$HOME/prebuilt-otel" \
-            -DBUILD_TESTING=ON -DBUILD_EXAMPLE=ON
+            -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON
           cmake --build . -j${nproc}
           ctest

--- a/exporters/geneva/CMakeLists.txt
+++ b/exporters/geneva/CMakeLists.txt
@@ -105,7 +105,7 @@ if(OPENTELEMETRY_INSTALL)
     PATTERN "*.h")
 endif()
 
-if(BUILD_EXAMPLE)
+if(BUILD_EXAMPLES)
   add_executable(example_metrics example/example_metrics.cc
                                  example/foo_library.cc)
   target_link_libraries(example_metrics opentelemetry_exporter_geneva_metrics)

--- a/exporters/geneva/INSTALL.md
+++ b/exporters/geneva/INSTALL.md
@@ -55,7 +55,7 @@ for instructions.
      inclusion in shared libraries, this variable is used.
    - `-DBUILD_SHARED_LIBS=ON` : To build shared libraries for the targets.
    - `-DBUILD_TESTING=ON` : Build the unit-tests
-   - `-DBUILD_EXAMPLE=ON`: Build the example code which generates measurements and collects/exports metrics periodically
+   - `-DBUILD_EXAMPLES=ON`: Build the example code which generates measurements and collects/exports metrics periodically
 
 4. Once build configuration is created, build the exporter:
 

--- a/exporters/user_events/CMakeLists.txt
+++ b/exporters/user_events/CMakeLists.txt
@@ -7,8 +7,9 @@ if(WIN32)
   message(FATAL_ERROR "user_events exporter is Linux only for now")
 endif()
 
-option(BUILD_EXAMPLE "Build example" ON)
+option(BUILD_EXAMPLES "Build example" ON)
 option(BUILD_TESTING "Build tests" ON)
+option(BUILD_TRACEPOINTS "Build tracepoints library" ON)
 
 project(opentelemetry-user_events-exporter)
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
@@ -26,10 +27,12 @@ if(MAIN_PROJECT)
   find_package(opentelemetry-cpp REQUIRED)
 endif()
 
-# don't build samples and tools from LinuxTracepoints.
-set(BUILD_SAMPLES OFF)
-set(BUILD_TOOLS OFF)
-add_subdirectory(third_party/LinuxTracepoints)
+if(BUILD_TRACEPOINTS)
+  # don't build samples and tools from LinuxTracepoints.
+  set(BUILD_SAMPLES OFF)
+  set(BUILD_TOOLS OFF)
+  add_subdirectory(third_party/LinuxTracepoints)
+endif()
 
 include_directories(include)
 
@@ -72,7 +75,7 @@ else()
            opentelemetry_otlp_recordable tracepoint)
 endif()
 
-if(BUILD_EXAMPLE)
+if(BUILD_EXAMPLES)
   add_executable(user_events_logs example/logs/main.cc
                                   example/logs/foo_library.cc)
   target_link_libraries(user_events_logs ${CMAKE_THREAD_LIBS_INIT}


### PR DESCRIPTION
# Changes
- Rename `BUILD_EXAMPLE` to `BUILD_EXAMPLES` which seems to be a more standard argument name in CMake for skipping the build of examples. In addition, in [Vcpkg for opentelemetry-cpp port](https://github.com/microsoft/vcpkg/blob/3c76dc55f8bd2b7f4824bcd860055094bfbbb9ea/ports/opentelemetry-cpp/portfile.cmake#L68), `BUILD_EXAMPLES` is the one used.
- Add option to skip the build of Tracepoints library. This will be used for Vcpkg build, as we will set Tracepoint library as a dependency of the feature.