### PR TITLE
[Geneva] fix C++ standard version in Dockerfile

### DIFF
--- a/exporters/user_events/CMakeLists.txt
+++ b/exporters/user_events/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.12)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if (MAIN_PROJECT)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
 
 if(WIN32)
   message(FATAL_ERROR "user_events exporter is Linux only for now")

--- a/exporters/user_events/Docker/Dockerfile
+++ b/exporters/user_events/Docker/Dockerfile
@@ -38,7 +38,7 @@ RUN cd /work && \
     git clone --recursive --depth=1 https://github.com/open-telemetry/opentelemetry-cpp.git && \
     cd opentelemetry-cpp && \
     mkdir build && cd build && \
-    cmake -G Ninja -D CMAKE_BUILD_TYPE=Debug -D BUILD_TESTING=0 -D WITH_OTLP_HTTP=1 -D WITH_OTLP_GRPC=0 .. && \
+    cmake -G Ninja -D CMAKE_BUILD_TYPE=Debug -D BUILD_TESTING=0 -D WITH_OTLP_HTTP=1 -D WITH_OTLP_GRPC=0 -D WITH_STL=CXX17.. && \
     ninja && \
     ninja install
 


### PR DESCRIPTION
Also take CXX standard value from parent project if this exporter is not built as main project.