### PR TITLE
[CI] Add CI for instrumentation/boost_log

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,3 @@
 instrumentation/httpd/ @TomRoSystems @open-telemetry/cpp-contrib-approvers
 instrumentation/nginx/ @seemk @tobiasstadler @open-telemetry/cpp-contrib-approvers
 instrumentation/otel-webserver-module/ @kpratyus @ajaynagariya @debajitdas @open-telemetry/cpp-contrib-approvers
-instrumentation/instrumentation/boost_log/ @chusitoo @open-telemetry/cpp-contrib-approvers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,4 @@
 instrumentation/httpd/ @TomRoSystems @open-telemetry/cpp-contrib-approvers
 instrumentation/nginx/ @seemk @tobiasstadler @open-telemetry/cpp-contrib-approvers
 instrumentation/otel-webserver-module/ @kpratyus @ajaynagariya @debajitdas @open-telemetry/cpp-contrib-approvers
+instrumentation/instrumentation/boost_log/ @chusitoo @open-telemetry/cpp-contrib-approvers

--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -45,10 +45,19 @@ jobs:
             libgtest-dev \
             libbenchmark-dev
 
-      - name: run tests
+      - name: build opentelemetry-cpp
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
           cd "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
-          cmake .. -G Ninja -D OPENTELEMETRY_EXTERNAL_COMPONENT_PATH=${GITHUB_WORKSPACE}/opentelemetry-cpp-contrib/instrumentation/boost_log
+          cmake .. -G Ninja
+          cmake --build . -j$(nproc)
+          cmake install
+
+      - name: build boost_log contrib
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/boost_log/build"
+          cd "${GITHUB_WORKSPACE}/boost_log/build"
+          cmake ../../opentelemetry-cpp-contrib/instrumentation/boost_log -G Ninja
           cmake --build . -j$(nproc)
           ctest -j1 --output-on-failure
+

--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -51,7 +51,7 @@ jobs:
           cd "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
           cmake .. -G Ninja
           cmake --build . -j$(nproc)
-          cmake install
+          make install
 
       - name: build boost_log contrib
         run: |

--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -51,7 +51,7 @@ jobs:
           cd "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
           cmake .. -G Ninja
           cmake --build . -j$(nproc)
-          make install
+          cmake --install .
 
       - name: build boost_log contrib
         run: |

--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -43,13 +43,14 @@ jobs:
             protobuf-compiler \
             libgmock-dev \
             libgtest-dev \
-            libbenchmark-dev
+            libbenchmark-dev \
+            libboost-all-dev
 
       - name: build opentelemetry-cpp
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
           cd "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
-          cmake .. -G Ninja
+          cmake .. -G Ninja -DBUILD_TESTING=OFF -DWITH_BENCHMARK=OFF
           cmake --build . -j$(nproc)
           cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 

--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -53,6 +53,8 @@ jobs:
             libbenchmark-dev \
             libboost-log-dev
 
+      # This is needed because libgmock-dev libgtest-dev installs 1.11,
+      # and 1.11 breaks the build.
       - name: build googletest 1.12
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/googletest/build"
@@ -73,7 +75,12 @@ jobs:
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/boost_log/build"
           cd "${GITHUB_WORKSPACE}/boost_log/build"
-          cmake ../../opentelemetry-cpp-contrib/instrumentation/boost_log -G Ninja -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/sandbox" -DBUILD_TESTING=ON -DWITH_EXAMPLES=ON -DOPENTELEMETRY_INSTALL=ON
+          cmake ../../opentelemetry-cpp-contrib/instrumentation/boost_log \
+            -G Ninja \
+            -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/sandbox" \
+            -DBUILD_TESTING=ON \
+            -DWITH_EXAMPLES=ON \
+            -DOPENTELEMETRY_INSTALL=ON
           cmake --build . -j$(nproc)
           ctest -j1 --output-on-failure
           cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"

--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
           cd "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
-          cmake .. -G Ninja -DBUILD_TESTING=OFF -DWITH_BENCHMARK=OFF -DOPENTELEMETRY_INSTALL=ON
+          cmake .. -G Ninja -DBUILD_TESTING=OFF -DWITH_BENCHMARK=OFF -DOPENTELEMETRY_INSTALL=ON -DWITH_STL=CXX14
           cmake --build . -j$(nproc)
           cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 

--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -51,13 +51,13 @@ jobs:
           cd "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
           cmake .. -G Ninja
           cmake --build . -j$(nproc)
-          cmake --install .
+          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 
       - name: build boost_log contrib
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/boost_log/build"
           cd "${GITHUB_WORKSPACE}/boost_log/build"
-          cmake ../../opentelemetry-cpp-contrib/instrumentation/boost_log -G Ninja
+          cmake ../../opentelemetry-cpp-contrib/instrumentation/boost_log -G Ninja -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/sandbox"
           cmake --build . -j$(nproc)
           ctest -j1 --output-on-failure
 

--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -18,6 +18,13 @@ jobs:
     name: CMake Linux
     runs-on: ubuntu-latest
     steps:
+      - name: checkout googletest
+        uses: actions/checkout@v3
+        with:
+          repository: "google/googletest"
+          ref: "release-1.12.1"
+          path: "googletest"
+          submodules: "recursive"
       - name: checkout opentelemetry-cpp-contrib
         uses: actions/checkout@v3
         with:
@@ -45,6 +52,14 @@ jobs:
             libgtest-dev \
             libbenchmark-dev \
             libboost-log-dev
+
+      - name: build googletest 1.12
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/googletest/build"
+          cd "${GITHUB_WORKSPACE}/googletest/build"
+          cmake .. -G Ninja
+          cmake --build . -j$(nproc)
+          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 
       - name: build opentelemetry-cpp
         run: |

--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: opentelemetry-cpp-contrib
-          submodules: "recursive"
+          # submodules: "recursive"
       - name: checkout opentelemetry-cpp
         uses: actions/checkout@v3
         with:
@@ -65,7 +65,7 @@ jobs:
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
           cd "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
-          cmake .. -G Ninja -DBUILD_TESTING=OFF -DWITH_BENCHMARK=OFF -DOPENTELEMETRY_INSTALL=ON -DWITH_STL=CXX14
+          cmake .. -G Ninja -DBUILD_TESTING=OFF -DWITH_BENCHMARK=OFF -DOPENTELEMETRY_INSTALL=ON
           cmake --build . -j$(nproc)
           cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 
@@ -73,7 +73,7 @@ jobs:
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/boost_log/build"
           cd "${GITHUB_WORKSPACE}/boost_log/build"
-          cmake ../../opentelemetry-cpp-contrib/instrumentation/boost_log -G Ninja -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/sandbox" -DBUILD_TESTING=ON -DOPENTELEMETRY_INSTALL=ON
+          cmake ../../opentelemetry-cpp-contrib/instrumentation/boost_log -G Ninja -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/sandbox" -DBUILD_TESTING=ON -DWITH_EXAMPLES=ON -DOPENTELEMETRY_INSTALL=ON
           cmake --build . -j$(nproc)
           ctest -j1 --output-on-failure
           cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"

--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -1,0 +1,54 @@
+name: boost_log
+
+on:
+  push:
+    branches:
+      - '*'
+    path:
+      - 'instrumentation/boost_log/**'
+      - '.github/workflows/boost_log.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'instrumentation/boost_log/**'
+      - '.github/workflows/boost_log.yml'
+
+jobs:
+  cmake_linux:
+    name: CMake Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout opentelemetry-cpp-contrib
+        uses: actions/checkout@v3
+        with:
+          path: opentelemetry-cpp-contrib
+          submodules: "recursive"
+      - name: checkout opentelemetry-cpp
+        uses: actions/checkout@v3
+        with:
+          repository: "open-telemetry/opentelemetry-cpp"
+          ref: "v1.14.2"
+          path: "opentelemetry-cpp"
+          submodules: "recursive"
+      - name: setup dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y --no-install-recommends --no-install-suggests \
+            build-essential \
+            cmake \
+            ninja-build \
+            libssl-dev \
+            libcurl4-openssl-dev \
+            libprotobuf-dev \
+            protobuf-compiler \
+            libgmock-dev \
+            libgtest-dev \
+            libbenchmark-dev
+
+      - name: run tests
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
+          cd "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
+          cmake .. -G Ninja -D OPENTELEMETRY_EXTERNAL_COMPONENT_PATH=${GITHUB_WORKSPACE}/opentelemetry-cpp-contrib/instrumentation/boost_log
+          cmake --build . -j$(nproc)
+          ctest -j1 --output-on-failure

--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -44,13 +44,13 @@ jobs:
             libgmock-dev \
             libgtest-dev \
             libbenchmark-dev \
-            libboost-all-dev
+            libboost-log-dev
 
       - name: build opentelemetry-cpp
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
           cd "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
-          cmake .. -G Ninja -DBUILD_TESTING=OFF -DWITH_BENCHMARK=OFF
+          cmake .. -G Ninja -DBUILD_TESTING=OFF -DWITH_BENCHMARK=OFF -DOPENTELEMETRY_INSTALL=ON
           cmake --build . -j$(nproc)
           cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 
@@ -58,7 +58,8 @@ jobs:
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/boost_log/build"
           cd "${GITHUB_WORKSPACE}/boost_log/build"
-          cmake ../../opentelemetry-cpp-contrib/instrumentation/boost_log -G Ninja -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/sandbox"
+          cmake ../../opentelemetry-cpp-contrib/instrumentation/boost_log -G Ninja -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/sandbox" -DBUILD_TESTING=ON -DOPENTELEMETRY_INSTALL=ON
           cmake --build . -j$(nproc)
           ctest -j1 --output-on-failure
+          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 

--- a/instrumentation/boost_log/CMakeLists.txt
+++ b/instrumentation/boost_log/CMakeLists.txt
@@ -8,7 +8,7 @@ set(this_target opentelemetry_boost_log_sink)
 project(${this_target})
 
 find_package(opentelemetry-cpp REQUIRED)
-find_package(Boost COMPONENTS log REQUIRED)
+find_package(Boost 1.73 COMPONENTS log REQUIRED)
 
 add_library(${this_target} src/sink.cc)
 
@@ -69,6 +69,8 @@ if(OPENTELEMETRY_INSTALL)
 endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
+  find_package(GTest 1.12 REQUIRED)
+
   set(testname sink_test)
 
   include(GoogleTest)
@@ -81,9 +83,9 @@ if(BUILD_TESTING)
   )
 
   target_link_libraries(${testname} PRIVATE
-    gmock
-    gtest
-    gtest_main
+    GTest::gmock
+    GTest::gtest
+    GTest::gtest_main
     Boost::log
     opentelemetry-cpp::ostream_log_record_exporter
     ${this_target}


### PR DESCRIPTION
Fixes #420 

Fixed CMakeLists:

* Require GTest 1.12.0. Building with 1.11 breaks the build due to a gtest bug.
* Require Boost.Log 1.73, as documented in the README.md. Building with 1.66 breaks the build, as found locally.

Relevant links:

* https://github.com/google/googletest/releases/tag/release-1.12.0
  * Fixes the GMock issue, but does not advertise 1.12
* https://github.com/google/googletest/releases/tag/release-1.12.1
  * Fixes the GMock issue, and properly advertises 1.12.1