### PR TITLE
[CI] Add CI for instrumentation/glog

### DIFF
--- a/.github/workflows/glog.yml
+++ b/.github/workflows/glog.yml
@@ -68,10 +68,10 @@ jobs:
           cmake --build . -j$(nproc)
           cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 
-      - name: build glog contrib
+      - name: build instrumentation/glog contrib
         run: |
-          mkdir -p "${GITHUB_WORKSPACE}/glog/build"
-          cd "${GITHUB_WORKSPACE}/glog/build"
+          mkdir -p "${GITHUB_WORKSPACE}/instrumentation-glog/build"
+          cd "${GITHUB_WORKSPACE}/instrumentation-glog/build"
           cmake ../../opentelemetry-cpp-contrib/instrumentation/glog \
             -G Ninja \
             -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/sandbox" \

--- a/.github/workflows/glog.yml
+++ b/.github/workflows/glog.yml
@@ -29,7 +29,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "google/glog"
-          ref: "v0.7.0"
+          # TODO: upgrade to v0.7.0 and fix deprecation warnings
+          ref: "v0.6.0"
           path: "glog"
           submodules: "recursive"
       - name: checkout opentelemetry-cpp-contrib

--- a/.github/workflows/glog.yml
+++ b/.github/workflows/glog.yml
@@ -28,8 +28,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "google/glog"
-          # TODO: upgrade to v0.7.0 and fix deprecation warnings
-          ref: "v0.6.0"
+          ref: "v0.7.0"
           path: "glog"
       - name: checkout opentelemetry-cpp-contrib
         uses: actions/checkout@v3

--- a/.github/workflows/glog.yml
+++ b/.github/workflows/glog.yml
@@ -18,6 +18,13 @@ jobs:
     name: CMake Linux
     runs-on: ubuntu-latest
     steps:
+      - name: checkout googletest
+        uses: actions/checkout@v3
+        with:
+          repository: "google/googletest"
+          ref: "release-1.12.1"
+          path: "googletest"
+          submodules: "recursive"
       - name: checkout glog
         uses: actions/checkout@v3
         with:
@@ -51,6 +58,16 @@ jobs:
             libgmock-dev \
             libgtest-dev \
             libbenchmark-dev
+
+      # This is needed because libgmock-dev libgtest-dev installs 1.11,
+      # and 1.11 breaks the build.
+      - name: build googletest 1.12
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/googletest/build"
+          cd "${GITHUB_WORKSPACE}/googletest/build"
+          cmake .. -G Ninja
+          cmake --build . -j$(nproc)
+          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 
       - name: build glog
         run: |

--- a/.github/workflows/glog.yml
+++ b/.github/workflows/glog.yml
@@ -24,7 +24,6 @@ jobs:
           repository: "google/googletest"
           ref: "release-1.12.1"
           path: "googletest"
-          submodules: "recursive"
       - name: checkout glog
         uses: actions/checkout@v3
         with:
@@ -32,12 +31,10 @@ jobs:
           # TODO: upgrade to v0.7.0 and fix deprecation warnings
           ref: "v0.6.0"
           path: "glog"
-          submodules: "recursive"
       - name: checkout opentelemetry-cpp-contrib
         uses: actions/checkout@v3
         with:
           path: opentelemetry-cpp-contrib
-          # submodules: "recursive"
       - name: checkout opentelemetry-cpp
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/glog.yml
+++ b/.github/workflows/glog.yml
@@ -1,0 +1,84 @@
+name: glog
+
+on:
+  push:
+    branches:
+      - '*'
+    path:
+      - 'instrumentation/glog/**'
+      - '.github/workflows/glog.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'instrumentation/glog/**'
+      - '.github/workflows/glog.yml'
+
+jobs:
+  cmake_linux:
+    name: CMake Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout glog
+        uses: actions/checkout@v3
+        with:
+          repository: "google/glog"
+          ref: "v0.7.0"
+          path: "glog"
+          submodules: "recursive"
+      - name: checkout opentelemetry-cpp-contrib
+        uses: actions/checkout@v3
+        with:
+          path: opentelemetry-cpp-contrib
+          # submodules: "recursive"
+      - name: checkout opentelemetry-cpp
+        uses: actions/checkout@v3
+        with:
+          repository: "open-telemetry/opentelemetry-cpp"
+          ref: "v1.14.2"
+          path: "opentelemetry-cpp"
+          submodules: "recursive"
+      - name: setup dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y --no-install-recommends --no-install-suggests \
+            build-essential \
+            cmake \
+            ninja-build \
+            libssl-dev \
+            libcurl4-openssl-dev \
+            libprotobuf-dev \
+            protobuf-compiler \
+            libgmock-dev \
+            libgtest-dev \
+            libbenchmark-dev
+
+      - name: build glog
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/glog/build"
+          cd "${GITHUB_WORKSPACE}/glog/build"
+          cmake .. -G Ninja
+          cmake --build . -j$(nproc)
+          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
+
+      - name: build opentelemetry-cpp
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
+          cd "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
+          cmake .. -G Ninja -DBUILD_TESTING=OFF -DWITH_BENCHMARK=OFF -DOPENTELEMETRY_INSTALL=ON
+          cmake --build . -j$(nproc)
+          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
+
+      - name: build glog contrib
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/glog/build"
+          cd "${GITHUB_WORKSPACE}/glog/build"
+          cmake ../../opentelemetry-cpp-contrib/instrumentation/glog \
+            -G Ninja \
+            -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/sandbox" \
+            -DBUILD_TESTING=ON \
+            -DWITH_EXAMPLES=ON \
+            -DOPENTELEMETRY_INSTALL=ON
+          cmake --build . -j$(nproc)
+          ctest -j1 --output-on-failure
+          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
+

--- a/instrumentation/boost_log/CMakeLists.txt
+++ b/instrumentation/boost_log/CMakeLists.txt
@@ -71,8 +71,6 @@ endif() # OPENTELEMETRY_INSTALL
 if(BUILD_TESTING)
   find_package(GTest 1.12 REQUIRED)
 
-  enable_testing()
-
   set(testname sink_test)
 
   include(GoogleTest)

--- a/instrumentation/boost_log/CMakeLists.txt
+++ b/instrumentation/boost_log/CMakeLists.txt
@@ -71,6 +71,8 @@ endif() # OPENTELEMETRY_INSTALL
 if(BUILD_TESTING)
   find_package(GTest 1.12 REQUIRED)
 
+  enable_testing()
+
   set(testname sink_test)
 
   include(GoogleTest)

--- a/instrumentation/glog/CMakeLists.txt
+++ b/instrumentation/glog/CMakeLists.txt
@@ -71,6 +71,8 @@ endif() # OPENTELEMETRY_INSTALL
 if(BUILD_TESTING)
   find_package(GTest 1.12 REQUIRED)
 
+  enable_testing()
+
   set(testname sink_test)
 
   include(GoogleTest)

--- a/instrumentation/glog/CMakeLists.txt
+++ b/instrumentation/glog/CMakeLists.txt
@@ -8,7 +8,7 @@ set(this_target opentelemetry_glog_sink)
 project(${this_target})
 
 find_package(opentelemetry-cpp REQUIRED)
-find_package(glog REQUIRED)
+find_package(glog 0.7.0 REQUIRED)
 
 add_library(${this_target} src/sink.cc)
 

--- a/instrumentation/glog/CMakeLists.txt
+++ b/instrumentation/glog/CMakeLists.txt
@@ -69,6 +69,8 @@ if(OPENTELEMETRY_INSTALL)
 endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
+  find_package(GTest REQUIRED)
+
   set(testname sink_test)
 
   include(GoogleTest)
@@ -81,8 +83,8 @@ if(BUILD_TESTING)
   )
 
   target_link_libraries(${testname} PRIVATE
-    gmock
-    gtest
+    GTest::gmock
+    GTest::gtest
     glog::glog
     opentelemetry-cpp::ostream_log_record_exporter
     ${this_target}

--- a/instrumentation/glog/CMakeLists.txt
+++ b/instrumentation/glog/CMakeLists.txt
@@ -69,7 +69,7 @@ if(OPENTELEMETRY_INSTALL)
 endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
-  find_package(GTest REQUIRED)
+  find_package(GTest 1.12 REQUIRED)
 
   set(testname sink_test)
 

--- a/instrumentation/glog/README.md
+++ b/instrumentation/glog/README.md
@@ -9,7 +9,7 @@
 
 - Current release tested only with Ubuntu 20.04.6 LTS
 - OpenTelemetry >= v1.12.0 
-- glog >= v0.3.5
+- glog >= v0.7.0
 
 ### Usage
 

--- a/instrumentation/glog/include/opentelemetry/instrumentation/glog/sink.h
+++ b/instrumentation/glog/include/opentelemetry/instrumentation/glog/sink.h
@@ -12,13 +12,6 @@
 namespace google
 {
 
-// The LogMessageTime class was introduced sometime in v0.6.0
-// Since there is no versioning available in this lib, we identify it based on the presence of this
-// include guard that was added in the required version
-#if defined(GLOG_EXPORT_H)
-#  define GLOG_VERSION_HAS_LOGMESSAGETIME
-#endif
-
 class OpenTelemetrySink : public google::LogSink
 {
 public:
@@ -41,7 +34,6 @@ public:
     }
   }
 
-#if defined(GLOG_VERSION_HAS_LOGMESSAGETIME)
   void send(google::LogSeverity,
             const char *,
             const char *,
@@ -49,15 +41,6 @@ public:
             const google::LogMessageTime &,
             const char *,
             size_t) override;
-#else
-  void send(google::LogSeverity,
-            const char *,
-            const char *,
-            int,
-            const struct ::tm *,
-            const char *,
-            size_t) override;
-#endif
 };
 
 }  // namespace google

--- a/instrumentation/glog/src/sink.cc
+++ b/instrumentation/glog/src/sink.cc
@@ -14,7 +14,6 @@
 namespace google
 {
 
-#if defined(GLOG_VERSION_HAS_LOGMESSAGETIME)
 void OpenTelemetrySink::send(google::LogSeverity severity,
                              const char *full_filename,
                              const char * /* base_filename */,
@@ -23,18 +22,6 @@ void OpenTelemetrySink::send(google::LogSeverity severity,
                              const char *message,
                              size_t message_len)
 {
-#else
-void OpenTelemetrySink::send(google::LogSeverity severity,
-                             const char *full_filename,
-                             const char * /* base_filename */,
-                             int line,
-                             const struct std::tm * /* time_tm */,
-                             const char *message,
-                             size_t message_len)
-{
-  // Compensate for the lack of precision in older versions
-  const auto timestamp = std::chrono::system_clock::now();
-#endif
 
   static constexpr auto kLoggerName  = "Google logger";
   static constexpr auto kLibraryName = "glog";
@@ -48,14 +35,9 @@ void OpenTelemetrySink::send(google::LogSeverity severity,
     using namespace opentelemetry::trace::SemanticConventions;
     using namespace std::chrono;
 
-#if defined(GLOG_VERSION_HAS_LOGMESSAGETIME)
-    static constexpr auto secs_to_msecs = duration_cast<microseconds>(seconds{1}).count();
-    const auto timestamp = microseconds(secs_to_msecs * logmsgtime.timestamp() + logmsgtime.usec());
-#endif
-
     log_record->SetSeverity(levelToSeverity(severity));
     log_record->SetBody(opentelemetry::nostd::string_view(message, message_len));
-    log_record->SetTimestamp(system_clock::time_point(timestamp));
+    log_record->SetTimestamp(logmsgtime.when());
     log_record->SetAttribute(kCodeFilepath, full_filename);
     log_record->SetAttribute(kCodeLineno, line);
     logger->EmitLogRecord(std::move(log_record));


### PR DESCRIPTION
Fixes #421

Fixed CMakeLists:

* Require GTest 1.12.0. Building with 1.11 breaks the build due to a gtest bug.

Upgraded to google/glog 0.7.0

* Fixed CMakeLists
* Removed `GLOG_VERSION_HAS_LOGMESSAGETIME`
* Fixed warnings related to timstamps.
