### PR TITLE
[CI] Add CI for instrumentation/log4cxx

### DIFF
--- a/.github/workflows/log4cxx.yml
+++ b/.github/workflows/log4cxx.yml
@@ -18,13 +18,16 @@ jobs:
     name: CMake Linux
     runs-on: ubuntu-latest
     steps:
-#      - name: checkout googletest
-#        uses: actions/checkout@v3
-#        with:
-#          repository: "google/googletest"
-#          ref: "release-1.12.1"
-#          path: "googletest"
-#          submodules: "recursive"
+      - name: checkout googletest
+        uses: actions/checkout@v3
+        with:
+          repository: "google/googletest"
+          ref: "release-1.12.1"
+      - name: checkout log4cxx
+        uses: actions/checkout@v3
+        with:
+          repository: "apache/log4cxx"
+          ref: "rel/v1.2.0"
       - name: checkout opentelemetry-cpp-contrib
         uses: actions/checkout@v3
         with:
@@ -53,15 +56,25 @@ jobs:
             libbenchmark-dev \
             liblog4cxx-dev
 
-#      # This is needed because libgmock-dev libgtest-dev installs 1.11,
-#      # and 1.11 breaks the build.
-#      - name: build googletest 1.12
-#        run: |
-#          mkdir -p "${GITHUB_WORKSPACE}/googletest/build"
-#          cd "${GITHUB_WORKSPACE}/googletest/build"
-#          cmake .. -G Ninja
-#          cmake --build . -j$(nproc)
-#          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
+      # This is needed because libgmock-dev libgtest-dev installs 1.11,
+      # and 1.11 breaks the build.
+      - name: build googletest 1.12
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/googletest/build"
+          cd "${GITHUB_WORKSPACE}/googletest/build"
+          cmake .. -G Ninja
+          cmake --build . -j$(nproc)
+          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
+
+      # This is needed because liblog4cxx-dev installs 0.12.1-4,
+      # and v1.0.0 is required
+      - name: build log4cxx
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/log4cxx/build"
+          cd "${GITHUB_WORKSPACE}/log4cxx/build"
+          cmake .. -G Ninja
+          cmake --build . -j$(nproc)
+          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 
       - name: build opentelemetry-cpp
         run: |

--- a/.github/workflows/log4cxx.yml
+++ b/.github/workflows/log4cxx.yml
@@ -60,12 +60,9 @@ jobs:
             liblog4cxx-dev
 
       # This is needed because libgmock-dev libgtest-dev installs 1.11,
-      # and 1.11 breaks the build.
+      # and v1.12 is required
       - name: build googletest 1.12
         run: |
-          # Debug CI break
-          ls -l "${GITHUB_WORKSPACE}/"
-          ls -l "${GITHUB_WORKSPACE}/googletest/"
           mkdir -p "${GITHUB_WORKSPACE}/googletest/build"
           cd "${GITHUB_WORKSPACE}/googletest/build"
           cmake .. -G Ninja

--- a/.github/workflows/log4cxx.yml
+++ b/.github/workflows/log4cxx.yml
@@ -1,0 +1,87 @@
+name: log4cxx
+
+on:
+  push:
+    branches:
+      - '*'
+    path:
+      - 'instrumentation/log4cxx/**'
+      - '.github/workflows/log4cxx.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'instrumentation/log4cxx/**'
+      - '.github/workflows/log4cxx.yml'
+
+jobs:
+  cmake_linux:
+    name: CMake Linux
+    runs-on: ubuntu-latest
+    steps:
+#      - name: checkout googletest
+#        uses: actions/checkout@v3
+#        with:
+#          repository: "google/googletest"
+#          ref: "release-1.12.1"
+#          path: "googletest"
+#          submodules: "recursive"
+      - name: checkout opentelemetry-cpp-contrib
+        uses: actions/checkout@v3
+        with:
+          path: opentelemetry-cpp-contrib
+          # submodules: "recursive"
+      - name: checkout opentelemetry-cpp
+        uses: actions/checkout@v3
+        with:
+          repository: "open-telemetry/opentelemetry-cpp"
+          ref: "v1.14.2"
+          path: "opentelemetry-cpp"
+          submodules: "recursive"
+      - name: setup dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y --no-install-recommends --no-install-suggests \
+            build-essential \
+            cmake \
+            ninja-build \
+            libssl-dev \
+            libcurl4-openssl-dev \
+            libprotobuf-dev \
+            protobuf-compiler \
+            libgmock-dev \
+            libgtest-dev \
+            libbenchmark-dev \
+            liblog4cxx-dev
+
+#      # This is needed because libgmock-dev libgtest-dev installs 1.11,
+#      # and 1.11 breaks the build.
+#      - name: build googletest 1.12
+#        run: |
+#          mkdir -p "${GITHUB_WORKSPACE}/googletest/build"
+#          cd "${GITHUB_WORKSPACE}/googletest/build"
+#          cmake .. -G Ninja
+#          cmake --build . -j$(nproc)
+#          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
+
+      - name: build opentelemetry-cpp
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
+          cd "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"
+          cmake .. -G Ninja -DBUILD_TESTING=OFF -DWITH_BENCHMARK=OFF -DOPENTELEMETRY_INSTALL=ON
+          cmake --build . -j$(nproc)
+          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
+
+      - name: build instrumentation/log4cxx contrib
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/instrumentation-log4cxx/build"
+          cd "${GITHUB_WORKSPACE}/instrumentation-log4cxx/build"
+          cmake ../../opentelemetry-cpp-contrib/instrumentation/log4cxx \
+            -G Ninja \
+            -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/sandbox" \
+            -DBUILD_TESTING=ON \
+            -DWITH_EXAMPLES=ON \
+            -DOPENTELEMETRY_INSTALL=ON
+          cmake --build . -j$(nproc)
+          ctest -j1 --output-on-failure
+          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
+

--- a/.github/workflows/log4cxx.yml
+++ b/.github/workflows/log4cxx.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           repository: "google/googletest"
           ref: "release-1.12.1"
-      - name: checkout log4cxx
+      - name: checkout logging-log4cxx
         uses: actions/checkout@v3
         with:
-          repository: "apache/log4cxx"
+          repository: "apache/logging-log4cxx"
           ref: "rel/v1.2.0"
       - name: checkout opentelemetry-cpp-contrib
         uses: actions/checkout@v3
@@ -68,10 +68,10 @@ jobs:
 
       # This is needed because liblog4cxx-dev installs 0.12.1-4,
       # and v1.0.0 is required
-      - name: build log4cxx
+      - name: build logging-log4cxx
         run: |
-          mkdir -p "${GITHUB_WORKSPACE}/log4cxx/build"
-          cd "${GITHUB_WORKSPACE}/log4cxx/build"
+          mkdir -p "${GITHUB_WORKSPACE}/logging-log4cxx/build"
+          cd "${GITHUB_WORKSPACE}/logging-log4cxx/build"
           cmake .. -G Ninja
           cmake --build . -j$(nproc)
           cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"

--- a/.github/workflows/log4cxx.yml
+++ b/.github/workflows/log4cxx.yml
@@ -24,7 +24,6 @@ jobs:
           repository: "google/googletest"
           ref: "release-1.12.1"
           path: "googletest"
-          submodules: "recursive"
       - name: checkout logging-log4cxx
         uses: actions/checkout@v3
         with:
@@ -35,7 +34,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: opentelemetry-cpp-contrib
-          # submodules: "recursive"
       - name: checkout opentelemetry-cpp
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/log4cxx.yml
+++ b/.github/workflows/log4cxx.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           repository: "apache/logging-log4cxx"
           ref: "rel/v1.2.0"
+          path: "logging-log4cxx"
       - name: checkout opentelemetry-cpp-contrib
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/log4cxx.yml
+++ b/.github/workflows/log4cxx.yml
@@ -24,6 +24,7 @@ jobs:
           repository: "google/googletest"
           ref: "release-1.12.1"
           path: "googletest"
+          submodules: "recursive"
       - name: checkout logging-log4cxx
         uses: actions/checkout@v3
         with:
@@ -61,6 +62,9 @@ jobs:
       # and 1.11 breaks the build.
       - name: build googletest 1.12
         run: |
+          # Debug CI break
+          ls -l "${GITHUB_WORKSPACE}/"
+          ls -l "${GITHUB_WORKSPACE}/googletest/"
           mkdir -p "${GITHUB_WORKSPACE}/googletest/build"
           cd "${GITHUB_WORKSPACE}/googletest/build"
           cmake .. -G Ninja

--- a/.github/workflows/log4cxx.yml
+++ b/.github/workflows/log4cxx.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           repository: "google/googletest"
           ref: "release-1.12.1"
+          path: "googletest"
       - name: checkout logging-log4cxx
         uses: actions/checkout@v3
         with:

--- a/instrumentation/log4cxx/CMakeLists.txt
+++ b/instrumentation/log4cxx/CMakeLists.txt
@@ -84,7 +84,7 @@ if(OPENTELEMETRY_INSTALL)
 endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
-  find_package(GTest REQUIRED)
+  find_package(GTest 1.12 REQUIRED)
 
   set(testname appender_test)
 

--- a/instrumentation/log4cxx/CMakeLists.txt
+++ b/instrumentation/log4cxx/CMakeLists.txt
@@ -84,6 +84,8 @@ if(OPENTELEMETRY_INSTALL)
 endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
+  find_package(GTest REQUIRED)
+
   set(testname appender_test)
 
   include(GoogleTest)
@@ -97,9 +99,9 @@ if(BUILD_TESTING)
   )
 
   target_link_libraries(${testname} PRIVATE
-    gmock
-    gtest
-    gtest_main
+    GTest::gmock
+    GTest::gtest
+    GTest::gtest_main
     log4cxx
     opentelemetry-cpp::ostream_log_record_exporter
     ${this_target}

--- a/instrumentation/log4cxx/CMakeLists.txt
+++ b/instrumentation/log4cxx/CMakeLists.txt
@@ -86,6 +86,8 @@ endif() # OPENTELEMETRY_INSTALL
 if(BUILD_TESTING)
   find_package(GTest 1.12 REQUIRED)
 
+  enable_testing()
+
   set(testname appender_test)
 
   include(GoogleTest)

--- a/instrumentation/log4cxx/include/opentelemetry/instrumentation/log4cxx/appender.h
+++ b/instrumentation/log4cxx/include/opentelemetry/instrumentation/log4cxx/appender.h
@@ -66,6 +66,4 @@ public:
   void append(const spi::LoggingEventPtr &event, helpers::Pool &) override;
 };
 
-IMPLEMENT_LOG4CXX_OBJECT(OpenTelemetryAppender)
-
 }  // namespace log4cxx

--- a/instrumentation/log4cxx/src/appender.cc
+++ b/instrumentation/log4cxx/src/appender.cc
@@ -11,6 +11,8 @@
 namespace log4cxx
 {
 
+IMPLEMENT_LOG4CXX_OBJECT(OpenTelemetryAppender)
+
 void OpenTelemetryAppender::append(const spi::LoggingEventPtr &event, helpers::Pool &)
 {
   static constexpr auto kLibraryName = "log4cxx";


### PR DESCRIPTION
Fixes #422

Fixed CMakeLists:

* Require GTest 1.12.0. Building with 1.11 breaks the build due to a gtest bug.

Fixed link issue:

* Moved `IMPLEMENT_LOG4CXX_OBJECT(OpenTelemetryAppender)` from header to implementation