### PR TITLE
Adding missing root span attributes and a Directive to configure root span name (operation name)

### DIFF
--- a/instrumentation/otel-webserver-module/README.md
+++ b/instrumentation/otel-webserver-module/README.md
@@ -180,6 +180,7 @@ Currently, Nginx Webserver module monitores some fixed set of modules, which get
 |*NginxModuleAttributes*           |                | OPTIONAL: Can be used to pass additionalccustom attributes to the span, nginx variables are also supported. All elements must be separated by a space, and different attribute key value pairs must be separated by a comma( even the comma needs to be separated by space). e.g. ```NginxModuleAttributes     Key1 Value1 , Key2 $request_uri;``` |
 |*NginxModuleIgnorePaths*           |               | OPTIONAL: Request URIs matching the Regex will not be monitored. Multiple space separated Regex can be provided( `'\'` symbol needs to be used carefully, Nginx treats `'\'` as a escape sequence, thus if the Regex sequence contains a `'\'`, it need to be replaced by `'\\'`, likewise if sequence contains `'\\'`, it need to be written as `'\\\\'` e.g. `.*\.html` -> `.*\\.html` ) e.g. ```NginxModuleIgnorePaths               .*\\.html /test_.*;```|
 |*NginxModulePropagatorType*                   | w3c                 | OPTIONAL: Specify the Propagator used by the instrumentation (W3C and B3 propagators available). e.g.```NginxModulePropagatorType                  b3;```|
+|*NginxModuleOperationName*                   |                 | OPTIONAL: Specify the operation name (span name) for any specific endpoint.  e.g.```NginxModuleOperationName                  My_Backend;```|
 
 
 

--- a/instrumentation/otel-webserver-module/include/core/api/Payload.h
+++ b/instrumentation/otel-webserver-module/include/core/api/Payload.h
@@ -46,6 +46,9 @@ class RequestPayload
     std::string target;
     std::string flavor;
     std::string client_ip;
+	std::string user_agent;
+	std::string operation_name;
+	long peer_port;
     long port = 80;
 
 public:
@@ -68,6 +71,10 @@ public:
     void set_target(const char* aTarget) {target = aTarget; }
     void set_flavor(const char* aflavor) {flavor = aflavor; }
     void set_client_ip(const char* clientIp) {client_ip = clientIp; }
+	void set_user_agent(const char* userAgent) {user_agent = userAgent; }
+	void set_operation_name(const char* operationName) {operation_name = operationName; }
+	
+	void set_peer_port(long aPeerPort) {peer_port = aPeerPort; }
     void set_port(long aPort) {port = aPort; }
 
 
@@ -83,6 +90,9 @@ public:
     std::string& get_target() {return target; }
     std::string& get_flavor() {return flavor; }
     std::string& get_client_ip() {return client_ip; }
+	std::string& get_user_agent() {return user_agent; }
+	std::string& get_operation_name() {return operation_name; }
+	long get_peer_port() {return peer_port; }
     long get_port() {return port; }
     std::unordered_map<std::string, std::string>& get_request_headers() {
     	return request_headers;

--- a/instrumentation/otel-webserver-module/include/core/api/opentelemetry_ngx_api.h
+++ b/instrumentation/otel-webserver-module/include/core/api/opentelemetry_ngx_api.h
@@ -45,12 +45,15 @@ typedef struct {
     const char* http_post_param;
     const char* request_method;
     const char* client_ip;
+    const char* user_agent;
+    const char* operation_name;
 
     http_headers* propagation_headers;
     http_headers* request_headers;
 
     int propagation_count;
     int request_headers_count;
+    int peer_port;
 }request_payload;
 
 typedef struct {

--- a/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkConstants.h
+++ b/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkConstants.h
@@ -37,11 +37,11 @@ const std::string kAttrHTTPClientIP           = "http.client_ip";
 const std::string kAttrHTTPStatusCode         = "http.status_code";
 const std::string kAttrNETHostPort            = "net.server.port";
 const std::string kAttrRequestProtocol        = "request_protocol";
-const std::string kHTTPFlavor1_0                 = "1.0";
-const std::string kHTTPFlavor1_1                = "1.1";
+const std::string kHTTPFlavor1_0              = "1.0";
+const std::string kHTTPFlavor1_1              = "1.1";
 const std::string kOtelAttributes             = "otel.attribute.";
-const std::string kAttrHTTPUserAgent           = "http.user_agent";
-const std::string kAttrNETPeerPort           = "net.remote.port";
+const std::string kAttrHTTPUserAgent          = "http.user_agent";
+const std::string kAttrNETPeerPort            = "net.remote.port";
 
 constexpr int HTTP_ERROR_1XX = 100;
 constexpr int HTTP_ERROR_4XX = 400;

--- a/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkConstants.h
+++ b/instrumentation/otel-webserver-module/include/core/sdkwrapper/SdkConstants.h
@@ -35,12 +35,13 @@ const std::string kAttrHTTPUrl                = "http.url";
 const std::string kAttrHTTPFlavor             = "http.flavor";
 const std::string kAttrHTTPClientIP           = "http.client_ip";
 const std::string kAttrHTTPStatusCode         = "http.status_code";
-const std::string kAttrNETHostPort            = "net.host.port";
+const std::string kAttrNETHostPort            = "net.server.port";
 const std::string kAttrRequestProtocol        = "request_protocol";
 const std::string kHTTPFlavor1_0                 = "1.0";
 const std::string kHTTPFlavor1_1                = "1.1";
 const std::string kOtelAttributes             = "otel.attribute.";
-
+const std::string kAttrHTTPUserAgent           = "http.user_agent";
+const std::string kAttrNETPeerPort           = "net.remote.port";
 
 constexpr int HTTP_ERROR_1XX = 100;
 constexpr int HTTP_ERROR_4XX = 400;

--- a/instrumentation/otel-webserver-module/src/core/api/RequestProcessingEngine.cpp
+++ b/instrumentation/otel-webserver-module/src/core/api/RequestProcessingEngine.cpp
@@ -64,7 +64,7 @@ OTEL_SDK_STATUS_CODE RequestProcessingEngine::startRequest(
         return OTEL_STATUS(payload_reflector_is_null);
     }
 
-    std::string spanName = m_spanNamer->getSpanName(payload->get_uri());
+    std::string spanName = (payload->get_operation_name().empty() ? m_spanNamer->getSpanName(payload->get_uri()) : payload->get_operation_name());
     otel::core::sdkwrapper::OtelKeyValueMap keyValueMap;
     keyValueMap[kAttrRequestProtocol] = payload->get_request_protocol();
     keyValueMap[kAttrHTTPServerName] = payload->get_server_name();
@@ -75,6 +75,8 @@ OTEL_SDK_STATUS_CODE RequestProcessingEngine::startRequest(
     keyValueMap[kAttrHTTPTarget] =payload->get_target();
     keyValueMap[kAttrHTTPFlavor] = payload->get_flavor();
     keyValueMap[kAttrHTTPClientIP] = payload->get_client_ip();
+    keyValueMap[kAttrHTTPUserAgent] = payload->get_user_agent();
+    keyValueMap[kAttrNETPeerPort] = payload->get_peer_port();
 
     auto& request_headers = payload->get_request_headers();
     for (auto itr = request_headers.begin(); itr != request_headers.end(); itr++) {

--- a/instrumentation/otel-webserver-module/src/core/api/RequestProcessingEngine.cpp
+++ b/instrumentation/otel-webserver-module/src/core/api/RequestProcessingEngine.cpp
@@ -76,8 +76,8 @@ OTEL_SDK_STATUS_CODE RequestProcessingEngine::startRequest(
     keyValueMap[kAttrHTTPTarget] =payload->get_target();
     keyValueMap[kAttrHTTPFlavor] = payload->get_flavor();
     keyValueMap[kAttrHTTPClientIP] = payload->get_client_ip();
-    keyValueMap[kAttrHTTPUserAgent] = payload->get_user_agent();
-    keyValueMap[kAttrNETPeerPort] = payload->get_peer_port();
+    // keyValueMap[kAttrHTTPUserAgent] = payload->get_user_agent();
+    // keyValueMap[kAttrNETPeerPort] = payload->get_peer_port();
 
     auto& request_headers = payload->get_request_headers();
     for (auto itr = request_headers.begin(); itr != request_headers.end(); itr++) {

--- a/instrumentation/otel-webserver-module/src/core/api/RequestProcessingEngine.cpp
+++ b/instrumentation/otel-webserver-module/src/core/api/RequestProcessingEngine.cpp
@@ -64,8 +64,7 @@ OTEL_SDK_STATUS_CODE RequestProcessingEngine::startRequest(
         return OTEL_STATUS(payload_reflector_is_null);
     }
 
-    // std::string spanName = (payload->get_operation_name().empty() ? m_spanNamer->getSpanName(payload->get_uri()) : payload->get_operation_name());
-    std::string spanName = m_spanNamer->getSpanName(payload->get_uri());
+    std::string spanName = (payload->get_operation_name().empty() ? m_spanNamer->getSpanName(payload->get_uri()) : payload->get_operation_name());
     otel::core::sdkwrapper::OtelKeyValueMap keyValueMap;
     keyValueMap[kAttrRequestProtocol] = payload->get_request_protocol();
     keyValueMap[kAttrHTTPServerName] = payload->get_server_name();
@@ -76,8 +75,8 @@ OTEL_SDK_STATUS_CODE RequestProcessingEngine::startRequest(
     keyValueMap[kAttrHTTPTarget] =payload->get_target();
     keyValueMap[kAttrHTTPFlavor] = payload->get_flavor();
     keyValueMap[kAttrHTTPClientIP] = payload->get_client_ip();
-    // keyValueMap[kAttrHTTPUserAgent] = payload->get_user_agent();
-    // keyValueMap[kAttrNETPeerPort] = payload->get_peer_port();
+    keyValueMap[kAttrHTTPUserAgent] = payload->get_user_agent();
+    keyValueMap[kAttrNETPeerPort] = payload->get_peer_port();
 
     auto& request_headers = payload->get_request_headers();
     for (auto itr = request_headers.begin(); itr != request_headers.end(); itr++) {

--- a/instrumentation/otel-webserver-module/src/core/api/RequestProcessingEngine.cpp
+++ b/instrumentation/otel-webserver-module/src/core/api/RequestProcessingEngine.cpp
@@ -64,7 +64,8 @@ OTEL_SDK_STATUS_CODE RequestProcessingEngine::startRequest(
         return OTEL_STATUS(payload_reflector_is_null);
     }
 
-    std::string spanName = (payload->get_operation_name().empty() ? m_spanNamer->getSpanName(payload->get_uri()) : payload->get_operation_name());
+    // std::string spanName = (payload->get_operation_name().empty() ? m_spanNamer->getSpanName(payload->get_uri()) : payload->get_operation_name());
+    std::string spanName = m_spanNamer->getSpanName(payload->get_uri());
     otel::core::sdkwrapper::OtelKeyValueMap keyValueMap;
     keyValueMap[kAttrRequestProtocol] = payload->get_request_protocol();
     keyValueMap[kAttrHTTPServerName] = payload->get_server_name();

--- a/instrumentation/otel-webserver-module/src/core/api/opentelemetry_ngx_api.cpp
+++ b/instrumentation/otel-webserver-module/src/core/api/opentelemetry_ngx_api.cpp
@@ -48,6 +48,10 @@ void populatePayload(request_payload* req_payload, void* load)
     payload->set_http_get_parameter(req_payload->http_get_param);
     payload->set_http_request_method(req_payload->request_method);
     payload->set_client_ip(req_payload->client_ip);
+    payload->set_user_agent(req_payload->user_agent);
+    payload->set_peer_port(req_payload->peer_port);
+    payload->set_operation_name(req_payload->operation_name);
+    
 
     for(int i=0; i<req_payload->propagation_count; i++){
         

--- a/instrumentation/otel-webserver-module/src/nginx/ngx_http_opentelemetry_module.h
+++ b/instrumentation/otel-webserver-module/src/nginx/ngx_http_opentelemetry_module.h
@@ -107,6 +107,7 @@ typedef struct {
     ngx_array_t  *nginxModuleAttributes;
     ngx_array_t  *nginxModuleIgnorePaths;
     ngx_str_t nginxModulePropagatorType;
+    ngx_str_t nginxModuleOperationName;
 
 } ngx_http_opentelemetry_loc_conf_t;
 

--- a/instrumentation/otel-webserver-module/test/unit/RequestProcessingEngine_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/RequestProcessingEngine_test.cpp
@@ -155,6 +155,7 @@ TEST(TestRequestProcessingEngine, StartRequest)
   keyValueMap[kAttrHTTPTarget] = (opentelemetry::nostd::string_view)"target";
   keyValueMap[kAttrHTTPFlavor] = (opentelemetry::nostd::string_view)"1.1";
   keyValueMap[kAttrHTTPClientIP] = (opentelemetry::nostd::string_view)"clientip";
+  keyValueMap[kAttrNETPeerPort] = (long)12345;
 	std::shared_ptr<otel::core::sdkwrapper::IScopedSpan> span;
 	span.reset(new MockScopedSpan);
 

--- a/instrumentation/otel-webserver-module/test/unit/RequestProcessingEngine_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/RequestProcessingEngine_test.cpp
@@ -82,22 +82,22 @@ MATCHER_P(HasMapVal, value, "") {
     		if(nostd::get<int64_t>(argkeyValue) != nostd::get<int64_t>(keyValue)){
     			valueMatches = false;
     		}
-    }
-    else if (nostd::holds_alternative<nostd::string_view>(keyValue)){
-    		
-    		if(nostd::get<nostd::string_view>(argkeyValue) != nostd::get<nostd::string_view>(keyValue)){
-    			  valueMatches = false;	
-    		}	
-    }
-    else if (nostd::holds_alternative<int32_t>(keyValue)){
-    		if(nostd::get<int32_t>(argkeyValue) != nostd::get<int32_t>(keyValue))
-    			valueMatches = false;
-    }
-    else if (nostd::holds_alternative<bool>(keyValue))
-    {
-    		if(nostd::get<bool>(argkeyValue) != nostd::get<bool>(keyValue))
-    			valueMatches = false;
-    }
+		}
+		else if (nostd::holds_alternative<nostd::string_view>(keyValue)){
+				
+				if(nostd::get<nostd::string_view>(argkeyValue) != nostd::get<nostd::string_view>(keyValue)){
+					valueMatches = false;	
+				}	
+		}
+		else if (nostd::holds_alternative<int32_t>(keyValue)){
+				if(nostd::get<int32_t>(argkeyValue) != nostd::get<int32_t>(keyValue))
+					valueMatches = false;
+		}
+		else if (nostd::holds_alternative<bool>(keyValue))
+		{
+				if(nostd::get<bool>(argkeyValue) != nostd::get<bool>(keyValue))
+					valueMatches = false;
+		}
 	}
 
 	return valueMatches;
@@ -137,28 +137,28 @@ TEST(TestRequestProcessingEngine, StartRequest)
 	payload.set_uri("dummy_span");
 	payload.set_server_name("localhost");
 	payload.set_host("host");
-  payload.set_http_request_method("GET");
-  payload.set_scheme("http");
-  payload.set_target("target");
-  payload.set_flavor("1.1");
-  payload.set_client_ip("clientip");
-  payload.set_port(80);
-  payload.set_user_agent("useragent");
-  payload.set_peer_port(12345);
+	payload.set_http_request_method("GET");
+	payload.set_scheme("http");
+	payload.set_target("target");
+	payload.set_flavor("1.1");
+	payload.set_client_ip("clientip");
+	payload.set_port(80);
+	payload.set_user_agent("useragent");
+	payload.set_peer_port(12345);
 
 
 	otel::core::sdkwrapper::OtelKeyValueMap keyValueMap;
-  keyValueMap[kAttrRequestProtocol] = (opentelemetry::nostd::string_view)"GET";
-  keyValueMap[kAttrHTTPServerName] = (opentelemetry::nostd::string_view)"localhost";
-  keyValueMap[kAttrHTTPMethod] = (opentelemetry::nostd::string_view)"GET";
-  keyValueMap[kAttrNetHostName] =(opentelemetry::nostd::string_view)"host";
-  keyValueMap[kAttrNETHostPort] = (long)80;
-  keyValueMap[kAttrHTTPScheme] = (opentelemetry::nostd::string_view)"http";
-  keyValueMap[kAttrHTTPTarget] = (opentelemetry::nostd::string_view)"target";
-  keyValueMap[kAttrHTTPFlavor] = (opentelemetry::nostd::string_view)"1.1";
-  keyValueMap[kAttrHTTPClientIP] = (opentelemetry::nostd::string_view)"clientip";
-  keyValueMap[kAttrNETPeerPort] = (long)12345;
-  keyValueMap[kAttrHTTPUserAgent] = (opentelemetry::nostd::string_view)"useragent";
+	keyValueMap[kAttrRequestProtocol] = (opentelemetry::nostd::string_view)"GET";
+	keyValueMap[kAttrHTTPServerName] = (opentelemetry::nostd::string_view)"localhost";
+	keyValueMap[kAttrHTTPMethod] = (opentelemetry::nostd::string_view)"GET";
+	keyValueMap[kAttrNetHostName] =(opentelemetry::nostd::string_view)"host";
+	keyValueMap[kAttrNETHostPort] = (long)80;
+	keyValueMap[kAttrHTTPScheme] = (opentelemetry::nostd::string_view)"http";
+	keyValueMap[kAttrHTTPTarget] = (opentelemetry::nostd::string_view)"target";
+	keyValueMap[kAttrHTTPFlavor] = (opentelemetry::nostd::string_view)"1.1";
+	keyValueMap[kAttrHTTPClientIP] = (opentelemetry::nostd::string_view)"clientip";
+	keyValueMap[kAttrNETPeerPort] = (long)12345;
+	keyValueMap[kAttrHTTPUserAgent] = (opentelemetry::nostd::string_view)"useragent";
 	std::shared_ptr<otel::core::sdkwrapper::IScopedSpan> span;
 	span.reset(new MockScopedSpan);
 
@@ -167,7 +167,7 @@ TEST(TestRequestProcessingEngine, StartRequest)
 		otel::core::sdkwrapper::SpanKind::SERVER,
 		HasMapVal(keyValueMap),
 		payload.get_http_headers())).
-	WillOnce(Return(span));
+		WillOnce(Return(span));
 
 	int* dummy = new int(2);
 	void* reqHandle = dummy;
@@ -180,7 +180,7 @@ TEST(TestRequestProcessingEngine, StartRequest)
 	EXPECT_EQ(reqContext->getContextName(), "ws_context");
 	EXPECT_FALSE(reqContext->hasActiveInteraction());
 
-  delete(dummy);
+  	delete(dummy);
 }
 
 

--- a/instrumentation/otel-webserver-module/test/unit/RequestProcessingEngine_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/RequestProcessingEngine_test.cpp
@@ -143,6 +143,8 @@ TEST(TestRequestProcessingEngine, StartRequest)
   payload.set_flavor("1.1");
   payload.set_client_ip("clientip");
   payload.set_port(80);
+  payload.set_user_agent("useragent");
+  payload.set_peer_port(12345);
 
 
 	otel::core::sdkwrapper::OtelKeyValueMap keyValueMap;
@@ -155,7 +157,8 @@ TEST(TestRequestProcessingEngine, StartRequest)
   keyValueMap[kAttrHTTPTarget] = (opentelemetry::nostd::string_view)"target";
   keyValueMap[kAttrHTTPFlavor] = (opentelemetry::nostd::string_view)"1.1";
   keyValueMap[kAttrHTTPClientIP] = (opentelemetry::nostd::string_view)"clientip";
-//   keyValueMap[kAttrNETPeerPort] = (long)12345;
+  keyValueMap[kAttrNETPeerPort] = (long)12345;
+  keyValueMap[kAttrHTTPUserAgent] = (opentelemetry::nostd::string_view)"useragent";
 	std::shared_ptr<otel::core::sdkwrapper::IScopedSpan> span;
 	span.reset(new MockScopedSpan);
 

--- a/instrumentation/otel-webserver-module/test/unit/RequestProcessingEngine_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/RequestProcessingEngine_test.cpp
@@ -156,6 +156,7 @@ TEST(TestRequestProcessingEngine, StartRequest)
   keyValueMap[kAttrHTTPFlavor] = (opentelemetry::nostd::string_view)"1.1";
   keyValueMap[kAttrHTTPClientIP] = (opentelemetry::nostd::string_view)"clientip";
   keyValueMap[kAttrNETPeerPort] = (long)12345;
+  keyValueMap[kAttrHTTPUserAgent] = (opentelemetry::nostd::string_view)"User-Agent";
 	std::shared_ptr<otel::core::sdkwrapper::IScopedSpan> span;
 	span.reset(new MockScopedSpan);
 

--- a/instrumentation/otel-webserver-module/test/unit/RequestProcessingEngine_test.cpp
+++ b/instrumentation/otel-webserver-module/test/unit/RequestProcessingEngine_test.cpp
@@ -155,8 +155,7 @@ TEST(TestRequestProcessingEngine, StartRequest)
   keyValueMap[kAttrHTTPTarget] = (opentelemetry::nostd::string_view)"target";
   keyValueMap[kAttrHTTPFlavor] = (opentelemetry::nostd::string_view)"1.1";
   keyValueMap[kAttrHTTPClientIP] = (opentelemetry::nostd::string_view)"clientip";
-  keyValueMap[kAttrNETPeerPort] = (long)12345;
-  keyValueMap[kAttrHTTPUserAgent] = (opentelemetry::nostd::string_view)"User-Agent";
+//   keyValueMap[kAttrNETPeerPort] = (long)12345;
 	std::shared_ptr<otel::core::sdkwrapper::IScopedSpan> span;
 	span.reset(new MockScopedSpan);
 


### PR DESCRIPTION
Added two features -
1. $remote_port and User-Agent header value was added as a root span attribute.
2. NginxModuleOperationName directive is introduced, it can be used specify root span name directly for endpoints.