### PR TITLE
[CI] Upgrade CI to opentelemetry-cpp 1.15.0

### DIFF
--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.14.2"
+          ref: "v1.15.0"
           path: "opentelemetry-cpp"
           submodules: "recursive"
       - name: setup dependencies

--- a/.github/workflows/geneva_metrics.yml
+++ b/.github/workflows/geneva_metrics.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.11.0"
+          ref: "v1.15.0"
           path: "otel_cpp"
           submodules: "recursive"
       - name: setup
@@ -34,7 +34,7 @@ jobs:
             ca-certificates wget git valgrind lcov
       - name: run tests
         run: |
-          sudo $GITHUB_WORKSPACE/otel_cpp/ci/setup_cmake.sh
+          sudo $GITHUB_WORKSPACE/otel_cpp/ci/setup_googletest.sh
           mkdir -p "$GITHUB_WORKSPACE/otel_cpp/build"
           cd "$GITHUB_WORKSPACE/otel_cpp/build"
           cmake .. -DOPENTELEMETRY_INSTALL=ON

--- a/.github/workflows/glog.yml
+++ b/.github/workflows/glog.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.14.2"
+          ref: "v1.15.0"
           path: "opentelemetry-cpp"
           submodules: "recursive"
       - name: setup dependencies

--- a/.github/workflows/log4cxx.yml
+++ b/.github/workflows/log4cxx.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.14.2"
+          ref: "v1.15.0"
           path: "opentelemetry-cpp"
           submodules: "recursive"
       - name: setup dependencies

--- a/.github/workflows/prometheus.yml
+++ b/.github/workflows/prometheus.yml
@@ -65,8 +65,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          # Fails in unit tests: ref: "v1.15.0"
-          ref: "v1.12.0"
+          ref: "v1.11.0"
           path: "otel_cpp"
           submodules: "recursive"
       - name: run tests
@@ -104,7 +103,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.15.0"
+          ref: "v1.11.0"
           path: "otel_cpp"
           submodules: "recursive"
       - name: setup

--- a/.github/workflows/prometheus.yml
+++ b/.github/workflows/prometheus.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.11.0"
+          ref: "v1.15.0"
           path: "otel_cpp"
           submodules: "recursive"
       - name: run tests
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.11.0"
+          ref: "v1.15.0"
           path: "otel_cpp"
           submodules: "recursive"
       - name: setup

--- a/.github/workflows/prometheus.yml
+++ b/.github/workflows/prometheus.yml
@@ -65,7 +65,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.15.0"
+          # Fails in unit tests: ref: "v1.15.0"
+          ref: "v1.12.0"
           path: "otel_cpp"
           submodules: "recursive"
       - name: run tests

--- a/.github/workflows/spdlog.yml
+++ b/.github/workflows/spdlog.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.14.2"
+          ref: "v1.15.0"
           path: "opentelemetry-cpp"
           submodules: "recursive"
       - name: setup dependencies

--- a/.github/workflows/user_events.yml
+++ b/.github/workflows/user_events.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.14.2"
+          ref: "v1.15.0"
           path: "opentelemetry-cpp"
           submodules: "recursive"
       - name: setup dependencies
@@ -47,7 +47,7 @@ jobs:
 
       - name: run tests
         run: |
-          sudo $GITHUB_WORKSPACE/opentelemetry-cpp/ci/setup_cmake.sh
+          sudo $GITHUB_WORKSPACE/opentelemetry-cpp/ci/setup_googletest.sh
           mkdir -p "$GITHUB_WORKSPACE/opentelemetry-cpp/build"
           cd "$GITHUB_WORKSPACE/opentelemetry-cpp/build"
           cmake .. -G Ninja -D OPENTELEMETRY_EXTERNAL_COMPONENT_PATH=$GITHUB_WORKSPACE/opentelemetry-cpp-contrib/exporters/user_events -D WITH_OTLP_HTTP=ON


### PR DESCRIPTION
Use opentelemetry-cpp 1.15.0 in CI for the following contributions:

* `boost_log`
* `geneva_metrics`
* `glog`
* `log4cxx`
* `spdlog`
* `user_events`

