### PR TITLE
[CI] Upgrade Prometheus CI to opentelemetry-cpp 1.15.0

### DIFF
--- a/.github/workflows/prometheus.yml
+++ b/.github/workflows/prometheus.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.11.0"
+          ref: "v1.15.0"
           path: "otel_cpp"
           submodules: "recursive"
       - name: run tests
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.11.0"
+          ref: "v1.15.0"
           path: "otel_cpp"
           submodules: "recursive"
       - name: setup

--- a/exporters/prometheus/repository.bzl
+++ b/exporters/prometheus/repository.bzl
@@ -19,10 +19,10 @@ def io_opentelemetry_cpp_contrib_deps():
     maybe(
         http_archive,
         name = "io_opentelemetry_cpp",
-        sha256 = "f30cd88bf898a5726d245eba882b8e81012021eb00df34109f4dfb203f005cea",
-        strip_prefix = "opentelemetry-cpp-1.11.0",
+        sha256 = "69b0fef380658e15be9d817bfcb32e3f5de96da652bcdce77b4e750ed8beddee",
+        strip_prefix = "opentelemetry-cpp-1.15.0",
         urls = [
-            "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.11.0.tar.gz",
+            "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.15.0.tar.gz",
         ],
     )
 

--- a/exporters/prometheus/repository.bzl
+++ b/exporters/prometheus/repository.bzl
@@ -30,13 +30,15 @@ def io_opentelemetry_cpp_contrib_deps():
     maybe(
         http_archive,
         name = "com_github_jupp0r_prometheus_cpp",
-        sha256 = "b4eff62bcdba10efd6210b9fa8a5b2505ad8ea6c211968be79aeb2c4c2f97338",
+        sha256 = "48dbad454d314b836cc667ec4def93ec4a6e4255fc8387c20cacb3b8b6faee30",
         # strip_prefix = "prometheus-cpp-1.1.0",
         # 1.1.0 with bazel 6 support
-        strip_prefix = "prometheus-cpp-81e208c250748657f1d5dab247e82c4429a931af",
+        # strip_prefix = "prometheus-cpp-81e208c250748657f1d5dab247e82c4429a931af",
+        strip_prefix = "prometheus-cpp-1.2.4",
         urls = [
             # "https://github.com/jupp0r/prometheus-cpp/archive/refs/tags/v1.1.0.tar.gz",
-            "https://github.com/jupp0r/prometheus-cpp/archive/81e208c250748657f1d5dab247e82c4429a931af.tar.gz",
+            # "https://github.com/jupp0r/prometheus-cpp/archive/81e208c250748657f1d5dab247e82c4429a931af.tar.gz",
+            "https://github.com/jupp0r/prometheus-cpp/archive/refs/tags/v1.2.4.tar.gz",
         ],
     )
 

--- a/exporters/prometheus/repository.bzl
+++ b/exporters/prometheus/repository.bzl
@@ -31,13 +31,8 @@ def io_opentelemetry_cpp_contrib_deps():
         http_archive,
         name = "com_github_jupp0r_prometheus_cpp",
         sha256 = "48dbad454d314b836cc667ec4def93ec4a6e4255fc8387c20cacb3b8b6faee30",
-        # strip_prefix = "prometheus-cpp-1.1.0",
-        # 1.1.0 with bazel 6 support
-        # strip_prefix = "prometheus-cpp-81e208c250748657f1d5dab247e82c4429a931af",
         strip_prefix = "prometheus-cpp-1.2.4",
         urls = [
-            # "https://github.com/jupp0r/prometheus-cpp/archive/refs/tags/v1.1.0.tar.gz",
-            # "https://github.com/jupp0r/prometheus-cpp/archive/81e208c250748657f1d5dab247e82c4429a931af.tar.gz",
             "https://github.com/jupp0r/prometheus-cpp/archive/refs/tags/v1.2.4.tar.gz",
         ],
     )

--- a/exporters/prometheus/test/prometheus_test_helper.h
+++ b/exporters/prometheus/test/prometheus_test_helper.h
@@ -25,7 +25,8 @@ inline opentelemetry::sdk::resource::Resource &GetEmptyResource()
 /**
  * Helper function to create ResourceMetrics
  */
-inline metric_sdk::ResourceMetrics CreateSumPointData()
+inline metric_sdk::ResourceMetrics CreateSumPointData(
+    opentelemetry::sdk::instrumentationscope::InstrumentationScope *scope)
 {
   metric_sdk::SumPointData sum_point_data{};
   sum_point_data.value_ = 10.0;
@@ -33,9 +34,7 @@ inline metric_sdk::ResourceMetrics CreateSumPointData()
   sum_point_data2.value_ = 20.0;
   metric_sdk::ResourceMetrics data;
   data.resource_ = &GetEmptyResource();
-  auto instrumentation_scope =
-      opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("library_name",
-                                                                             "1.9.1");
+
   metric_sdk::MetricData metric_data{
       metric_sdk::InstrumentDescriptor{"library_name", "description", "unit",
                                        metric_sdk::InstrumentType::kCounter,
@@ -46,11 +45,12 @@ inline metric_sdk::ResourceMetrics CreateSumPointData()
           {metric_sdk::PointAttributes{{"a1", "b1"}}, sum_point_data},
           {metric_sdk::PointAttributes{{"a2", "b2"}}, sum_point_data2}}};
   data.scope_metric_data_ = std::vector<metric_sdk::ScopeMetrics>{
-      {instrumentation_scope.get(), std::vector<metric_sdk::MetricData>{metric_data}}};
+      {scope, std::vector<metric_sdk::MetricData>{metric_data}}};
   return data;
 }
 
-inline metric_sdk::ResourceMetrics CreateHistogramPointData()
+inline metric_sdk::ResourceMetrics CreateHistogramPointData(
+    opentelemetry::sdk::instrumentationscope::InstrumentationScope *scope)
 {
   metric_sdk::HistogramPointData histogram_point_data{};
   histogram_point_data.boundaries_ = std::vector<double>{10.1, 20.2, 30.2};
@@ -65,9 +65,7 @@ inline metric_sdk::ResourceMetrics CreateHistogramPointData()
 
   metric_sdk::ResourceMetrics data;
   data.resource_ = &GetEmptyResource();
-  auto instrumentation_scope =
-      opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("library_name",
-                                                                             "1.9.1");
+
   metric_sdk::MetricData metric_data{
       metric_sdk::InstrumentDescriptor{"library_name", "description", "unit",
                                        metric_sdk::InstrumentType::kHistogram,
@@ -78,17 +76,16 @@ inline metric_sdk::ResourceMetrics CreateHistogramPointData()
           {metric_sdk::PointAttributes{{"a1", "b1"}}, histogram_point_data},
           {metric_sdk::PointAttributes{{"a2", "b2"}}, histogram_point_data2}}};
   data.scope_metric_data_ = std::vector<metric_sdk::ScopeMetrics>{
-      {instrumentation_scope.get(), std::vector<metric_sdk::MetricData>{metric_data}}};
+      {scope, std::vector<metric_sdk::MetricData>{metric_data}}};
   return data;
 }
 
-inline metric_sdk::ResourceMetrics CreateLastValuePointData()
+inline metric_sdk::ResourceMetrics CreateLastValuePointData(
+    opentelemetry::sdk::instrumentationscope::InstrumentationScope *scope)
 {
   metric_sdk::ResourceMetrics data;
   data.resource_ = &GetEmptyResource();
-  auto instrumentation_scope =
-      opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("library_name",
-                                                                             "1.2.0");
+
   metric_sdk::LastValuePointData last_value_point_data{};
   last_value_point_data.value_              = 10.0;
   last_value_point_data.is_lastvalue_valid_ = true;
@@ -107,17 +104,16 @@ inline metric_sdk::ResourceMetrics CreateLastValuePointData()
           {metric_sdk::PointAttributes{{"a1", "b1"}}, last_value_point_data},
           {metric_sdk::PointAttributes{{"a2", "b2"}}, last_value_point_data2}}};
   data.scope_metric_data_ = std::vector<metric_sdk::ScopeMetrics>{
-      {instrumentation_scope.get(), std::vector<metric_sdk::MetricData>{metric_data}}};
+      {scope, std::vector<metric_sdk::MetricData>{metric_data}}};
   return data;
 }
 
-inline metric_sdk::ResourceMetrics CreateDropPointData()
+inline metric_sdk::ResourceMetrics CreateDropPointData(
+    opentelemetry::sdk::instrumentationscope::InstrumentationScope *scope)
 {
   metric_sdk::ResourceMetrics data;
   data.resource_ = &GetEmptyResource();
-  auto instrumentation_scope =
-      opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("library_name",
-                                                                             "1.2.0");
+
   metric_sdk::DropPointData drop_point_data{};
   metric_sdk::DropPointData drop_point_data2{};
   metric_sdk::MetricData metric_data{
@@ -130,7 +126,7 @@ inline metric_sdk::ResourceMetrics CreateDropPointData()
           {metric_sdk::PointAttributes{{"a1", "b1"}}, drop_point_data},
           {metric_sdk::PointAttributes{{"a2", "b2"}}, drop_point_data2}}};
   data.scope_metric_data_ = std::vector<metric_sdk::ScopeMetrics>{
-      {instrumentation_scope.get(), std::vector<metric_sdk::MetricData>{metric_data}}};
+      {scope, std::vector<metric_sdk::MetricData>{metric_data}}};
   return data;
 }
 }  // namespace


### PR DESCRIPTION
Fix #432

## Changes

* CI CMake Build, upgraded opentelemetry-cpp to 1.15.0
* CI Bazel build, upgraded opentelemetry-cpp to 1.15.0
* CI Bazel build, upgraded prometheus-cpp to 1.2.4
* Fixed a build warning, `PrometheusPushExporterOptions::port` is a string
* Fixed a crashing bug in unit tests in `CreateSumPointData()`:
  * local variable `instrumentation_scope` is a `unique_ptr`
  * `instrumentation_scope.get()` is used to build the test data
  * `instrumentation_scope` goes out of scope, deleting the underlying pointer
  * the simulated data points to stale memory, leading to a crash when using `instrumentation_scope`
  * This happens with recent opentelemetry-cpp, where the prometheus exporter uses the scope
* Adjusted unit test `CollectionNotEnoughSpace`:
  * The prometheus exporter now exports the scope, as well as data
  * This increases the amount of data collected