### PR TITLE
fix(nginx): set error status on span with 5xx status code

### DIFF
--- a/instrumentation/nginx/src/otel_ngx_module.cpp
+++ b/instrumentation/nginx/src/otel_ngx_module.cpp
@@ -545,7 +545,14 @@ ngx_int_t FinishNgxSpan(ngx_http_request_t* req) {
   }
 
   auto span = context->request_span;
-  span->SetAttribute("http.status_code", req->headers_out.status);
+  const auto status_code = req->headers_out.status;
+  span->SetAttribute("http.status_code", status_code);
+
+  if (status_code >= 500) {
+    span->SetStatus(trace::StatusCode::kError);
+  } else {
+    span->SetStatus(trace::StatusCode::kOk);
+  }
 
   OtelNgxLocationConf* locConf = GetOtelLocationConf(req);
 


### PR DESCRIPTION
## Description
This PR enhances the `otel_ngx_module` to set the span status as "error" specifically when the HTTP request returns a `5xx` status code. For all other status codes, it sets the status as "ok". 