### PR TITLE
Fix for OtlpGrpcExporterOptions in otel-cpp >=1.13.0

### DIFF
--- a/instrumentation/nginx/src/otel_ngx_module.cpp
+++ b/instrumentation/nginx/src/otel_ngx_module.cpp
@@ -1021,7 +1021,8 @@ static std::unique_ptr<sdktrace::SpanExporter> CreateExporter(const OtelNgxAgent
   switch (conf->exporter.type) {
     case OtelExporterOTLP: {
       std::string endpoint = conf->exporter.endpoint;
-      otlp::OtlpGrpcExporterOptions opts{endpoint};
+      otlp::OtlpGrpcExporterOptions opts;
+      opts.endpoint = endpoint;
       opts.use_ssl_credentials = conf->exporter.use_ssl_credentials;
       opts.ssl_credentials_cacert_path = conf->exporter.ssl_credentials_cacert_path;
       exporter.reset(new otlp::OtlpGrpcExporter(opts));


### PR DESCRIPTION
Fix for building against opentelemetry-cpp 1.13.0 and later, caused by this PR: https://github.com/open-telemetry/opentelemetry-cpp/pull/2388:
```
[ 88%] Building CXX object CMakeFiles/otel_ngx_module.dir/src/propagate.cpp.o
/opentelemetry-cpp-contrib/instrumentation/nginx/src/otel_ngx_module.cpp: In function 'ngx_int_t OtelGetTraceId(ngx_http_request_t*, ngx_http_variable_value_t*, uintptr_t)':
/opentelemetry-cpp-contrib/instrumentation/nginx/src/otel_ngx_module.cpp:268:81: warning: unused parameter 'data' [-Wunused-parameter]
  268 | OtelGetTraceId(ngx_http_request_t* req, ngx_http_variable_value_t* v, uintptr_t data) {
      |                                                                       ~~~~~~~~~~^~~~
/opentelemetry-cpp-contrib/instrumentation/nginx/src/otel_ngx_module.cpp: In function 'ngx_int_t OtelGetSpanId(ngx_http_request_t*, ngx_http_variable_value_t*, uintptr_t)':
/opentelemetry-cpp-contrib/instrumentation/nginx/src/otel_ngx_module.cpp:323:80: warning: unused parameter 'data' [-Wunused-parameter]
  323 | OtelGetSpanId(ngx_http_request_t* req, ngx_http_variable_value_t* v, uintptr_t data) {
      |                                                                      ~~~~~~~~~~^~~~
/opentelemetry-cpp-contrib/instrumentation/nginx/src/otel_ngx_module.cpp: In function 'std::unique_ptr<opentelemetry::v1::sdk::trace::SpanExporter> CreateExporter(const OtelNgxAgentConfig*)':
/opentelemetry-cpp-contrib/instrumentation/nginx/src/otel_ngx_module.cpp:1024:50: error: no matching function for call to 'opentelemetry::v1::exporter::otlp::OtlpGrpcExporterOptions::OtlpGrpcExporterOptions(<brace-enclosed initializer list>)'
 1024 |       otlp::OtlpGrpcExporterOptions opts{endpoint};
      |                                                  ^     
In file included from /install/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h:18,
                 from /opentelemetry-cpp-contrib/instrumentation/nginx/src/otel_ngx_module.cpp:5:
/install/include/opentelemetry/exporters/otlp/otlp_grpc_exporter_options.h:26:3: note: candidate: 'opentelemetry::v1::exporter::otlp::OtlpGrpcExporterOptions::OtlpGrpcExporterOptions()'
   26 |   OtlpGrpcExporterOptions();
      |   ^~~~~~~~~~~~~~~~~~~~~~~
/install/include/opentelemetry/exporters/otlp/otlp_grpc_exporter_options.h:26:3: note:   candidate expects 0 arguments, 1 provided
/install/include/opentelemetry/exporters/otlp/otlp_grpc_exporter_options.h:24:29: note: candidate: 'opentelemetry::v1::exporter::otlp::OtlpGrpcExporterOptions::OtlpGrpcExporterOptions(const opentelemetry::v1::exporter::otlp::OtlpGrpcExporterOptions&)'
   24 | struct OPENTELEMETRY_EXPORT OtlpGrpcExporterOptions : public OtlpGrpcClientOptions
      |                             ^~~~~~~~~~~~~~~~~~~~~~~
/install/include/opentelemetry/exporters/otlp/otlp_grpc_exporter_options.h:24:29: note:   no known conversion for argument 1 from 'std::string' {aka 'std::__cxx11::basic_string<char>'} to 'const opentelemetry::v1::exporter::otlp::OtlpGrpcExporterOptions&'
make[2]: *** [CMakeFiles/otel_ngx_module.dir/build.make:132: CMakeFiles/otel_ngx_module.dir/src/otel_ngx_module.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:111: CMakeFiles/otel_ngx_module.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```