### PR TITLE
fluentd exporter: Add support for DNS name lookup

### DIFF
--- a/exporters/fluentd/src/log/fluentd_exporter.cc
+++ b/exporters/fluentd/src/log/fluentd_exporter.cc
@@ -219,6 +219,14 @@ bool FluentdExporter::Initialize() {
   }
   addr_.reset(
       new SocketTools::SocketAddr(options_.endpoint.c_str(), is_unix_domain));
+  if (addr_->m_data_in.sin_family != AF_UNIX &&
+      addr_->m_data_in.sin_family != AF_INET &&
+      addr_->m_data_in.sin_family != AF_INET6)
+  {
+    LOG_ERROR("Invalid endpoint! %s", options_.endpoint.c_str());
+    return false;
+  }
+
   LOG_TRACE("connecting to %s", addr_->toString().c_str());
 
   return true;

--- a/exporters/fluentd/src/trace/fluentd_exporter.cc
+++ b/exporters/fluentd/src/trace/fluentd_exporter.cc
@@ -188,6 +188,13 @@ bool FluentdExporter::Initialize() {
 
   addr_.reset(
       new SocketTools::SocketAddr(options_.endpoint.c_str(), is_unix_domain));
+  if (addr_->m_data_in.sin_family != AF_UNIX &&
+      addr_->m_data_in.sin_family != AF_INET &&
+      addr_->m_data_in.sin_family != AF_INET6)
+  {
+    LOG_ERROR("Invalid endpoint! %s", options_.endpoint.c_str());
+    return false;
+  }
   LOG_TRACE("connecting to %s", addr_->toString().c_str());
 
   return true;


### PR DESCRIPTION
Add support for DNS lookups using getaddrinfo(3).
The API supports lookups of hostnames, IPv4, or IPv6 addresses.

This uses the first AF_INET or AF_INET6 address returned 
from the list and fails if none is available.

A followup PR triggers new lookups on socket failure.