### PR TITLE
fluentd exporter: Disconnect and retry DNS lookup on socket failure

### DIFF
--- a/exporters/fluentd/include/opentelemetry/exporters/fluentd/common/fluentd_common.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/fluentd/common/fluentd_common.h
@@ -142,6 +142,7 @@ struct FluentdExporterOptions {
   TransportFormat format = TransportFormat::kForward;
   std::string tag = "tag.service";
   size_t retry_count = 2; // number of retries before drop
+  uint32_t retry_delay_ms = 1000;
   std::string endpoint;
   bool convert_event_to_trace =
       false; // convert events to trace. Not used for Logs.

--- a/exporters/fluentd/src/trace/fluentd_exporter.cc
+++ b/exporters/fluentd/src/trace/fluentd_exporter.cc
@@ -220,6 +220,7 @@ bool FluentdExporter::Connect() {
  */
 bool FluentdExporter::Send(std::vector<uint8_t> &packet) {
   size_t retryCount = options_.retry_count;
+  auto retrySleepMs = std::chrono::milliseconds(options_.retry_delay_ms);
   while (retryCount--) {
     int error_code = 0;
     // Check if socket is Okay
@@ -231,8 +232,12 @@ bool FluentdExporter::Send(std::vector<uint8_t> &packet) {
     }
     // Reconnect if not Okay
     if (!connected_) {
+      Initialize(); // try a DNS lookup, etc
       // Establishing socket connection may take time
       if (!Connect()) {
+	if (retryCount) {
+	  std::this_thread::sleep_for(retrySleepMs);
+	}
         continue;
       }
       LOG_DEBUG("socket connected");
@@ -248,10 +253,15 @@ bool FluentdExporter::Send(std::vector<uint8_t> &packet) {
     }
 
     LOG_WARN("send failed, retrying %u ...", (unsigned int)retryCount);
+    Disconnect();
     // Retry to connect and/or send
+    if (retryCount) {
+      std::this_thread::sleep_for(retrySleepMs);
+    }
   }
 
   LOG_ERROR("send failed!");
+  Disconnect();
   return false;
 }
 


### PR DESCRIPTION
On socket failure, re-initialize the address info.

Along with #468, this triggers a new DNS lookup.

To prevent immediate retries that quickly exhaust the retry count,
add a retry_delay_ms to FluentdExporterOptions, defaulting to 1000ms.