### PR TITLE
[Geneva Exporter] Allocate exception from stack instead of heap

### DIFF
--- a/exporters/fluentd/include/opentelemetry/exporters/geneva/geneva_logger_exporter.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/geneva/geneva_logger_exporter.h
@@ -37,7 +37,7 @@ static inline bool InitializeGenevaExporter( const GenevaExporterOptions options
         return true;
     } else {
 #if defined(__EXCEPTIONS)
-        throw new std::runtime_error("Invalid endpoint! Unix domain socket should have unix:// as url-scheme");
+        throw std::runtime_error("Invalid endpoint! Unix domain socket should have unix:// as url-scheme");
 #endif
         return false;
     }

--- a/exporters/fluentd/include/opentelemetry/exporters/geneva/geneva_tracer_exporter.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/geneva/geneva_tracer_exporter.h
@@ -41,7 +41,7 @@ static inline bool InitializeGenevaExporter( const GenevaExporterOptions options
         return true;
     } else {
 #if defined(__EXCEPTIONS)
-        throw new std::runtime_error("Invalid endpoint! Unix domain socket should have unix:// as url-scheme");
+        throw std::runtime_error("Invalid endpoint! Unix domain socket should have unix:// as url-scheme");
 #endif
         return false;
     }

--- a/exporters/fluentd/src/log/fluentd_exporter.cc
+++ b/exporters/fluentd/src/log/fluentd_exporter.cc
@@ -213,7 +213,7 @@ bool FluentdExporter::Initialize() {
   else {
 #if defined(__EXCEPTIONS)
     // Customers MUST specify valid end-point configuration
-    throw new std::runtime_error("Invalid endpoint!");
+    throw std::runtime_error("Invalid endpoint!");
 #endif
     return false;
   }

--- a/exporters/fluentd/src/trace/fluentd_exporter.cc
+++ b/exporters/fluentd/src/trace/fluentd_exporter.cc
@@ -181,7 +181,7 @@ bool FluentdExporter::Initialize() {
   else {
 #if defined(__EXCEPTIONS)
     // Customers MUST specify valid end-point configuration
-    throw new std::runtime_error("Invalid endpoint!");
+    throw std::runtime_error("Invalid endpoint!");
 #endif
     return false;
   }


### PR DESCRIPTION
Throw a heap allocated object requires freeing it by the user code for exception handling, or there will be memory leak. Instead, destruction is stack allocated exception object is handled by the language which should be preferred.