### PR TITLE
Fix cmake find config of fluentd and update corresponding README

### DIFF
--- a/exporters/fluentd/README.md
+++ b/exporters/fluentd/README.md
@@ -34,6 +34,21 @@ For example:
     $ .../opentelemetry-cpp-contrib2/exporters/fluentd$ make
 ```
 
+### Incorporating into an existing CMake Project
+
+To use the library from a CMake project, you can locate it directly with
+ `find_package` and use the imported targets from generated package
+ configurations. As of now, this will import targets for both `trace` and `logs`.
+
+```cmake
+# CMakeLists.txt
+find_package(opentelemetry-cpp CONFIG REQUIRED)
+find_package(opentelemetry-fluentd CONFIG REQUIRED)
+...
+target_include_directories(foo PRIVATE ${OPENTELEMETRY_CPP_FLUENTD_INCLUDE_DIRS})
+target_link_libraries(foo PRIVATE ${OPENTELEMETRY_CPP_LIBRARIES} ${OPENTELEMETRY_CPP_FLUENTD_LIBRARY_DIRS})
+```
+
 ### Bazel Install Instructions
 
 TODO

--- a/exporters/fluentd/cmake/opentelemetry-cpp-fluentd-config.cmake.in
+++ b/exporters/fluentd/cmake/opentelemetry-cpp-fluentd-config.cmake.in
@@ -19,8 +19,8 @@
 #   OPENTELEMETRY_CPP_FLUENTD_VERSION           - Version of opentelemetry-cpp-fluentd.
 #
 # ::
-#   opentelemetry-cpp-fluentd::trace                    - Imported target of opentelemetry-cpp-fluentd::trace
-#   opentelemetry-cpp::logs                             - Imported target of opentelemetry-cpp-fluentd::logs
+#   opentelemetry-cpp-fluentd::trace                    - Imported target of opentelemetry-fluentd::trace
+#   opentelemetry-cpp::logs                             - Imported target of opentelemetry-fluentd::logs
 
 # =============================================================================
 # Copyright 2020 opentelemetry.
@@ -49,8 +49,8 @@ set(_OPENTELEMETRY_CPP_FLUENTD_LIBRARIES_TEST_TARGETS
         logs)
 
 foreach(_TEST_TARGET IN LISTS _OPENTELEMETRY_CPP_FLUENTD_LIBRARIES_TEST_TARGETS)
-        if(TARGET opentelemetry-fluentd-cpp::${_TEST_TARGET})
-                list(APPEND OPENTELEMETRY_CPP_FLUENTD_LIBRARIES opentelemetry-cpp-fluentd::${_TEST_TARGET})
+        if(TARGET opentelemetry-fluentd::${_TEST_TARGET})
+                list(APPEND OPENTELEMETRY_CPP_FLUENTD_LIBRARIES opentelemetry-fluentd::${_TEST_TARGET})
         else()
                 message("Target not found: " ${_TEST_TARGET})
         endif()


### PR DESCRIPTION
## Description
This PR raised for address issue #477, navigate to the issue to get more details.

## Changes
* Update the `exporters/fluentd/cmake/opentelemetry-cpp-fluentd-config.cmake.in` to make sure it works as expected.
* Add new section `Incorporating into an existing CMake Project` in the README of fluentd for better guide.

## Test && Validation
* Test in local linux system and can't provide a unitest (at least i dont know the correct way).

### Existing Behavior
Use `find_package(opentelemetry-fluentd CONFIG REQUIRED)` get empty `OPENTELEMETRY_CPP_FLUENTD_LIBRARY_DIRS` and `OPENTELEMETRY_CPP_FLUENTD_INCLUDE_DIRS`

### New Behavior
Now `OPENTELEMETRY_CPP_FLUENTD_LIBRARY_DIRS` and `OPENTELEMETRY_CPP_FLUENTD_INCLUDE_DIRS` works as expected:
* `OPENTELEMETRY_CPP_FLUENTD_LIBRARY_DIRS`: [opentelemetry-fluentd::trace, opentelemetry-fluentd::logs]
* `OPENTELEMETRY_CPP_FLUENTD_INCLUDE_DIRS`: same as the value of `OPENTELEMETRY_CPP_INCLUDE_DIRS`
