### PR TITLE
Rename the project to opentelemetry-cpp-fluentd

### DIFF
--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -19,7 +19,7 @@ cmake_minimum_required(VERSION 3.12)
 ##
 set(MAIN_PROJECT OFF)
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  project(opentelemetry-fluentd)
+  project(opentelemetry-cpp-fluentd)
   set(MAIN_PROJECT ON)
 endif()
 

--- a/exporters/fluentd/README.md
+++ b/exporters/fluentd/README.md
@@ -43,7 +43,7 @@ To use the library from a CMake project, you can locate it directly with
 ```cmake
 # CMakeLists.txt
 find_package(opentelemetry-cpp CONFIG REQUIRED)
-find_package(opentelemetry-fluentd CONFIG REQUIRED)
+find_package(opentelemetry-cpp-fluentd CONFIG REQUIRED)
 ...
 target_include_directories(foo PRIVATE ${OPENTELEMETRY_CPP_FLUENTD_INCLUDE_DIRS})
 target_link_libraries(foo PRIVATE ${OPENTELEMETRY_CPP_LIBRARIES} ${OPENTELEMETRY_CPP_FLUENTD_LIBRARY_DIRS})

--- a/exporters/fluentd/cmake/opentelemetry-cpp-fluentd-config.cmake.in
+++ b/exporters/fluentd/cmake/opentelemetry-cpp-fluentd-config.cmake.in
@@ -19,8 +19,8 @@
 #   OPENTELEMETRY_CPP_FLUENTD_VERSION           - Version of opentelemetry-cpp-fluentd.
 #
 # ::
-#   opentelemetry-cpp-fluentd::trace                    - Imported target of opentelemetry-fluentd::trace
-#   opentelemetry-cpp::logs                             - Imported target of opentelemetry-fluentd::logs
+#   opentelemetry-cpp-fluentd::trace                    - Imported target of oopentelemetry-cpp-fluentd::trace
+#   opentelemetry-cpp::logs                             - Imported target of opentelemetry-cpp-fluentd::logs
 
 # =============================================================================
 # Copyright 2020 opentelemetry.
@@ -49,8 +49,8 @@ set(_OPENTELEMETRY_CPP_FLUENTD_LIBRARIES_TEST_TARGETS
         logs)
 
 foreach(_TEST_TARGET IN LISTS _OPENTELEMETRY_CPP_FLUENTD_LIBRARIES_TEST_TARGETS)
-        if(TARGET opentelemetry-fluentd::${_TEST_TARGET})
-                list(APPEND OPENTELEMETRY_CPP_FLUENTD_LIBRARIES opentelemetry-fluentd::${_TEST_TARGET})
+        if(TARGET opentelemetry-cpp-fluentd::${_TEST_TARGET})
+                list(APPEND OPENTELEMETRY_CPP_FLUENTD_LIBRARIES opentelemetry-cpp-fluentd::${_TEST_TARGET})
         else()
                 message("Target not found: " ${_TEST_TARGET})
         endif()

--- a/exporters/fluentd/vcpkg.json
+++ b/exporters/fluentd/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-    "name": "opentelemetry-fluentd",
+    "name": "opentelemetry-cpp-fluentd",
     "version-semver": "2.0.0",
     "description": "mdsd/fluentd exporter for OpenTelemetry C++",
     "homepage": "https://github.com/niande-xbox/opentelemetry-cpp-contrib/tree/main/exporters/fluentd",


### PR DESCRIPTION
@ThomsonTan and @lalitb , As we discussed in PR #478, rename the project from `opentelemetry-fluentd` to `opentelemetry-cpp-fluentd`.

## Changes
* Change the project name in CMakeLists
* Change the project name in vcpkg
* Update cmake config and readme