### PR TITLE
[Geneva Exporter] Add env_properties to Geneva overrides header file

### DIFF
--- a/exporters/geneva-trace/include/opentelemetry/exporters/geneva/geneva_fields.h
+++ b/exporters/geneva-trace/include/opentelemetry/exporters/geneva/geneva_fields.h
@@ -75,6 +75,8 @@
 #  define ETW_VALUE_SPAN_START        "SpanStart"             /* ETW for Span Start      */
 #  define ETW_VALUE_SPAN_END          "SpanEnd"               /* ETW for Span Start      */
 
+# define ETW_FIELD_ENV_PROPERTIES     "env_properties"        /* ETW event_properties with JSON string */
+
 #  define ETW_FIELD_LOG_BODY          "body"                  /* Log body   */
 #  define ETW_FIELD_LOG_SEVERITY_TEXT "severityText"          /* Sev text  */
 #  define ETW_FIELD_LOG_SEVERITY_NUM  "severityNumber"        /* Sev num   */


### PR DESCRIPTION
The underlying ETW exporter supports attributes nesting under "env_properties" property, this should also be supported in Geneva exporter.

https://github.com/open-telemetry/opentelemetry-cpp/blob/84d427070899e4faf75d1a7be175e9c723a01171/exporters/etw/include/opentelemetry/exporters/etw/etw_fields.h#L137