### PR TITLE
[Geneva] Add nlohmann dependence when building as component

### DIFF
--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -72,7 +72,7 @@ else()
   target_link_libraries(
     opentelemetry_exporter_geneva_trace
     PUBLIC opentelemetry_trace opentelemetry_resources opentelemetry_common
-    INTERFACE nlohmann_json::nlohmann_json)
+      nlohmann_json::nlohmann_json)
 endif()
 
 # create fluentd logs exporter
@@ -93,7 +93,7 @@ else()
     target_link_libraries(
       opentelemetry_exporter_geneva_logs
       PUBLIC opentelemetry_logs opentelemetry_resources opentelemetry_common
-      INTERFACE nlohmann_json::nlohmann_json)
+        nlohmann_json::nlohmann_json)
 endif()
 
 if(nlohmann_json_clone)


### PR DESCRIPTION
When building Geneva(fluent) exporter as external component, it does need depend on nlohmann JSON as the header file is included. Extend the dependence type to PUBLIC or the `#include "nlohmann/json.hpp"` will fail.