### PR TITLE
CI: add nginx instrumentation release job

### DIFF
--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -6,13 +6,38 @@ on:
     paths:
       - 'instrumentation/nginx/**'
       - '.github/workflows/nginx.yml'
+    tags:
+      - 'nginx/*'
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
       - 'instrumentation/nginx/**'
       - '.github/workflows/nginx.yml'
-
 jobs:
+  create-release:
+    if: startsWith(github.ref, 'refs/tags/nginx')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release
+        uses: softprops/action-gh-release@v2
+  upload-release-artifacts:
+    if: startsWith(github.ref, 'refs/tags/nginx')
+    runs-on: ubuntu-latest
+    needs: [nginx-build-test, create-release]
+    steps:
+      - name: Create directory
+        run: |
+          mkdir artifacts
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Upload release artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          fail_on_unmatched_files: true
+          files: ./artifacts/*
   nginx-build-test:
     name: nginx
     runs-on: ubuntu-24.04
@@ -55,6 +80,7 @@ jobs:
           cd instrumentation/nginx
           docker build -t otel-nginx-test/nginx \
             --build-arg image=${{ matrix.image }} \
+            --build-arg nginx_version=${{ matrix.nginx }} \
             -f test/${{ env.dockerfile }} \
             --cache-from type=local,src=/tmp/buildx-cache/nginx \
             --cache-to type=local,dest=/tmp/buildx-cache/nginx-new \
@@ -80,11 +106,15 @@ jobs:
           mkdir -p /tmp/otel_ngx/
           docker build -f test/${{ env.dockerfile }} \
           --build-arg image=${{ matrix.image }} \
+          --build-arg nginx_version=${{ matrix.nginx }} \
           --target export \
           --output type=local,dest=/tmp/otel_ngx .
           echo "artifactName=otel_ngx_module-$(echo ${{ matrix.image }} | sed s/:/-/)-${{ matrix.nginx }}.so" >> $GITHUB_ENV
+      - name: rename artifact
+        run: |
+          mv /tmp/otel_ngx/otel_ngx_module.so /tmp/otel_ngx/${{ env.artifactName }}
       - name: upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.artifactName }}
-          path: /tmp/otel_ngx/otel_ngx_module.so
+          path: /tmp/otel_ngx/${{ env.artifactName }}


### PR DESCRIPTION
* CI now creates a new release for tags starting with `nginx`, e.g. `nginx/v0.1.0`.
* Adds artifacts to the release.

Fix: actually use the nginx version when building Docker images.