### PR TITLE
[Geneva] Remove reference to UDS for Windows

### DIFF
--- a/exporters/geneva/src/exporter.cc
+++ b/exporters/geneva/src/exporter.cc
@@ -22,17 +22,18 @@ Exporter::Exporter(const ExporterOptions &options)
     : options_(options), connection_string_parser_(options_.connection_string),
       data_transport_{nullptr} {
   if (connection_string_parser_.IsValid()) {
+#ifdef _WIN32
+    if (connection_string_parser_.transport_protocol_ ==
+             TransportProtocol::kETW) {
+      data_transport_ = std::unique_ptr<DataTransport>(
+          new ETWDataTransport(kBinaryHeaderSize));
+    }
+#else
     if (connection_string_parser_.transport_protocol_ ==
         TransportProtocol::kUNIX) {
       data_transport_ =
           std::unique_ptr<DataTransport>(new UnixDomainSocketDataTransport(
               connection_string_parser_.connection_string_));
-    }
-#ifdef _WIN32
-    else if (connection_string_parser_.transport_protocol_ ==
-             TransportProtocol::kETW) {
-      data_transport_ = std::unique_ptr<DataTransport>(
-          new ETWDataTransport(kBinaryHeaderSize));
     }
 #endif
   }


### PR DESCRIPTION
UDS header was removed for Windows in below PR https://github.com/open-telemetry/opentelemetry-cpp-contrib/pull/497, the use on the symbol `UnixDomainSocketDataTransport` should also be excluded.