### PR TITLE
[user_events] Set EventHeader name to the event_name property

### DIFF
--- a/.github/workflows/user_events.yml
+++ b/.github/workflows/user_events.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.18.0"
+          ref: "64a74bfadbdc10f8f8e3d0435b19d08de19537d1"
           path: "opentelemetry-cpp"
           submodules: "recursive"
       - name: setup dependencies

--- a/exporters/user_events/include/opentelemetry/exporters/user_events/logs/recordable.h
+++ b/exporters/user_events/include/opentelemetry/exporters/user_events/logs/recordable.h
@@ -124,7 +124,7 @@ private:
   size_t cs_part_b_bookmark_size_ = 0;
   size_t cs_part_c_bookmark_      = 0;
   size_t cs_part_c_bookmark_size_ = 0;
-  uint_8 severity_                = 0; 
+  uint8_t severity_               = 0;
   bool has_event_id_              = false;
 };
 

--- a/exporters/user_events/include/opentelemetry/exporters/user_events/logs/recordable.h
+++ b/exporters/user_events/include/opentelemetry/exporters/user_events/logs/recordable.h
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <cstdint>
-#include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/logs/severity.h"
+#include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/common/attribute_utils.h"
 #include "opentelemetry/sdk/logs/recordable.h"
 #include "opentelemetry/version.h"
@@ -117,7 +117,7 @@ public:
 
 private:
   ehd::EventBuilder event_builder_;
-  int64_t event_id_               = 0;
+  int64_t event_id_ = 0;
   nostd::string_view event_name_;
   int level_index_                = 0;
   size_t cs_part_b_bookmark_      = 0;

--- a/exporters/user_events/include/opentelemetry/exporters/user_events/logs/recordable.h
+++ b/exporters/user_events/include/opentelemetry/exporters/user_events/logs/recordable.h
@@ -117,11 +117,15 @@ public:
 
 private:
   ehd::EventBuilder event_builder_;
-  int level_index_;
+  int64_t event_id_               = 0;
+  nostd::string_view event_name_;
+  int level_index_                = 0;
   size_t cs_part_b_bookmark_      = 0;
   size_t cs_part_b_bookmark_size_ = 0;
   size_t cs_part_c_bookmark_      = 0;
   size_t cs_part_c_bookmark_size_ = 0;
+  uint_8 severity_                = 0; 
+  bool has_event_id_              = false;
 };
 
 }  // namespace logs

--- a/exporters/user_events/src/logs_exporter.cc
+++ b/exporters/user_events/src/logs_exporter.cc
@@ -52,9 +52,10 @@ sdk::common::ExportResult Exporter::Export(
     auto user_events_record =
         std::unique_ptr<Recordable>(static_cast<Recordable *>(record.release()));
 
-    user_events_record->PrepareExport();
-
-    // assert(user_events_record != nullptr, "Recordable is null");
+    if (!user_events_record->PrepareExport())
+    {
+      continue;
+    }
 
     int level_index = user_events_record->GetLevelIndex();
 

--- a/exporters/user_events/src/logs_exporter.cc
+++ b/exporters/user_events/src/logs_exporter.cc
@@ -19,10 +19,11 @@ namespace logs
 
 /*********************** Constructor ***********************/
 
-Exporter::Exporter(const ExporterOptions &options) noexcept : options_(options), provider_(options.provider_name)
+Exporter::Exporter(const ExporterOptions &options) noexcept
+    : options_(options), provider_(options.provider_name)
 {
   // Initialize the event sets
-  for (int i = 0; i < sizeof(event_levels_map)/sizeof(event_levels_map[0]); i++)
+  for (int i = 0; i < sizeof(event_levels_map) / sizeof(event_levels_map[0]); i++)
   {
     event_set_levels_[i] = provider_.RegisterSet(event_levels_map[i], 1);
   }

--- a/exporters/user_events/src/recordable.cc
+++ b/exporters/user_events/src/recordable.cc
@@ -104,10 +104,17 @@ void Recordable::SetTimestamp(opentelemetry::common::SystemTimestamp timestamp) 
 
 bool Recordable::PrepareExport() noexcept
 {
-  if (cs_part_b_bookmark_size_ > 0)
+  if (cs_part_b_bookmark_size_ == 0)
+  {
+    // Part B is mandatory for exporting to user_events.
+    OTEL_INTERNAL_LOG_ERROR("[user_events Log Exporter] Recordable: no data to export.");
+    return false;
+  }
+  else
   {
     event_builder_.SetStructFieldCount(cs_part_b_bookmark_, cs_part_b_bookmark_size_);
   }
+
   if (cs_part_c_bookmark_size_ > 0)
   {
     event_builder_.SetStructFieldCount(cs_part_c_bookmark_, cs_part_c_bookmark_size_);

--- a/exporters/user_events/src/recordable.cc
+++ b/exporters/user_events/src/recordable.cc
@@ -29,7 +29,7 @@ void Recordable::SetSeverity(api_logs::Severity severity) noexcept
     severity_value = 0;
   }
 
-  severity_ = severity_value;
+  severity_    = severity_value;
   level_index_ = (severity_value - 1) >> 2;
 }
 
@@ -53,7 +53,7 @@ void Recordable::SetBody(const opentelemetry::common::AttributeValue &message) n
                           event_field_format_default);
   auto severity_text = api_logs::SeverityNumToText[static_cast<uint32_t>(severity_)].data();
   event_builder_.AddString<char>("severityText", severity_text, event_field_format_default);
-  cs_part_b_bookmark_size_ = 4; // with the below body counted because it is available.
+  cs_part_b_bookmark_size_ = 4;  // with the below body counted because it is available.
 
   if (has_event_id_)
   {
@@ -67,8 +67,8 @@ void Recordable::SetBody(const opentelemetry::common::AttributeValue &message) n
 void Recordable::SetEventId(int64_t id, nostd::string_view name) noexcept
 {
   has_event_id_ = true;
-  event_id_= id;
-  event_name_ = name;
+  event_id_     = id;
+  event_name_   = name;
 }
 
 void Recordable::SetTraceId(const opentelemetry::trace::TraceId &trace_id) noexcept

--- a/exporters/user_events/src/recordable.cc
+++ b/exporters/user_events/src/recordable.cc
@@ -67,7 +67,7 @@ void Recordable::SetBody(const opentelemetry::common::AttributeValue &message) n
 void Recordable::SetEventId(int64_t id, nostd::string_view name) noexcept
 {
   has_event_id_ = true;
-  event_id_.id_ = id;
+  event_id_= id;
   event_name_ = name;
 }
 

--- a/exporters/user_events/src/recordable.cc
+++ b/exporters/user_events/src/recordable.cc
@@ -17,50 +17,58 @@ namespace logs
 
 namespace api_logs = opentelemetry::logs;
 
-Recordable::Recordable() noexcept
-{
-  event_builder_.Reset("OpenTelemetry-Logs");
-
-  utils::PopulateAttribute("__csver__", static_cast<uint16_t>(0x400), event_builder_);
-}
+Recordable::Recordable() noexcept {}
 
 void Recordable::SetSeverity(api_logs::Severity severity) noexcept
 {
   uint8_t severity_value = static_cast<uint8_t>(severity);
-  if (severity_value == 0 || severity_value > 24)
+  if (severity_value > 24)
   {
     OTEL_INTERNAL_LOG_ERROR(
         "[user_events Log Exporter] Recordable: invalid severity value: " << severity_value);
-    severity_value = 1;
+    severity_value = 0;
   }
 
+  severity_ = severity_value;
   level_index_ = (severity_value - 1) >> 2;
-
-  cs_part_b_bookmark_size_ += 2;
-  event_builder_.AddValue("severityNumber", static_cast<uint16_t>(severity_value),
-                          event_field_format_default);
-  auto severity_text = api_logs::SeverityNumToText[static_cast<uint32_t>(severity_value)].data();
-  event_builder_.AddString<char>("severityText", severity_text, event_field_format_default);
 }
 
 void Recordable::SetBody(const opentelemetry::common::AttributeValue &message) noexcept
 {
-  // Set intial bookmark size to 1 for body below.
-  cs_part_b_bookmark_size_++;
+  if (severity_ == 0)
+  {
+    OTEL_INTERNAL_LOG_ERROR("[user_events Log Exporter] Recordable: severity is not set.");
+    return;
+  }
+
+  auto event_name = !event_name_.empty() ? event_name_.data() : "OpenTelemetryLogs";
+
+  event_builder_.Reset(event_name);
+  utils::PopulateAttribute("__csver__", static_cast<uint16_t>(0x400), event_builder_);
+
   event_builder_.AddStruct("PartB", 1, 0, &cs_part_b_bookmark_);
   utils::PopulateAttribute("_typeName", "Log", event_builder_);
+
+  event_builder_.AddValue("severityNumber", static_cast<uint16_t>(severity_),
+                          event_field_format_default);
+  auto severity_text = api_logs::SeverityNumToText[static_cast<uint32_t>(severity_value)].data();
+  event_builder_.AddString<char>("severityText", severity_text, event_field_format_default);
+  cs_part_b_bookmark_size_ = 4; // with the below body counted because it is available.
+
+  if (has_event_id_)
+  {
+    utils::PopulateAttribute("eventId", event_id_, event_builder_);
+    cs_part_b_bookmark_size_++;
+  }
+
   utils::PopulateAttribute("body", message, event_builder_);
 }
 
 void Recordable::SetEventId(int64_t id, nostd::string_view name) noexcept
 {
-  cs_part_b_bookmark_size_++;
-  utils::PopulateAttribute("eventId", id, event_builder_);
-  if (!name.empty())
-  {
-    cs_part_b_bookmark_size_++;
-    utils::PopulateAttribute("name", name, event_builder_);
-  }
+  has_event_id_ = true;
+  event_id_.id_ = id;
+  event_name_ = name;
 }
 
 void Recordable::SetTraceId(const opentelemetry::trace::TraceId &trace_id) noexcept

--- a/exporters/user_events/src/recordable.cc
+++ b/exporters/user_events/src/recordable.cc
@@ -51,7 +51,7 @@ void Recordable::SetBody(const opentelemetry::common::AttributeValue &message) n
 
   event_builder_.AddValue("severityNumber", static_cast<uint16_t>(severity_),
                           event_field_format_default);
-  auto severity_text = api_logs::SeverityNumToText[static_cast<uint32_t>(severity_value)].data();
+  auto severity_text = api_logs::SeverityNumToText[static_cast<uint32_t>(severity_)].data();
   event_builder_.AddString<char>("severityText", severity_text, event_field_format_default);
   cs_part_b_bookmark_size_ = 4; // with the below body counted because it is available.
 


### PR DESCRIPTION
With below PR in main, the user_events Log exporter could create `EventBuilder` during calling into `Recordable` with `event_name`, and also no need to cache the Log attributes which would require extra dynamic memory allocation.

https://github.com/open-telemetry/opentelemetry-cpp/pull/3296