### PR TITLE
[user_events] Fix exporting attribute type in double

### DIFF
--- a/exporters/user_events/src/recordable.cc
+++ b/exporters/user_events/src/recordable.cc
@@ -41,7 +41,7 @@ void Recordable::SetBody(const opentelemetry::common::AttributeValue &message) n
     return;
   }
 
-  auto event_name = !event_name_.empty() ? event_name_.data() : "OpenTelemetryLogs";
+  auto event_name = !event_name_.empty() ? event_name_.data() : "Logs";
 
   event_builder_.Reset(event_name);
   utils::PopulateAttribute("__csver__", static_cast<uint16_t>(0x400), event_builder_);

--- a/exporters/user_events/src/utils.cc
+++ b/exporters/user_events/src/utils.cc
@@ -69,7 +69,7 @@ void PopulateAttribute(nostd::string_view key,
   {
     event_builder.AddValue(key_name, nostd::get<uint64_t>(value), event_field_format_default);
   }
-  else if (nostd::holds_alternative<double>(value), event_field_format_default)
+  else if (nostd::holds_alternative<double>(value))
   {
     event_builder.AddValue(key_name, nostd::get<double>(value), event_field_format_float);
   }


### PR DESCRIPTION
Also update the default event name to `Logs` to be consistent with other SDKs.