### PR TITLE
Add SocketDataTransport to support kTCP/kUDP

### DIFF
--- a/exporters/geneva/CMakeLists.txt
+++ b/exporters/geneva/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 
 include_directories(include)
 
-set(OTEL_GENEVA_EXPORTER_VERSION 1.0.0)
+set(OTEL_GENEVA_EXPORTER_VERSION 1.0.1)
 set(OTEL_GENEVA_EXPORTER_MAJOR_VERSION 1)
 
 function(set_target_version target_name)
@@ -38,10 +38,10 @@ if(WIN32)
   add_library(
     opentelemetry_exporter_geneva_metrics
     src/exporter.cc src/etw_data_transport.cc
-    src/unix_domain_socket_data_transport.cc)
+    src/socket_data_transport.cc)
 else()
   add_library(opentelemetry_exporter_geneva_metrics
-              src/exporter.cc src/unix_domain_socket_data_transport.cc)
+              src/exporter.cc src/socket_data_transport.cc)
 endif()
 
 if(MAIN_PROJECT)

--- a/exporters/geneva/cmake/package.cmake
+++ b/exporters/geneva/cmake/package.cmake
@@ -4,7 +4,7 @@ set(CPACK_PACKAGE_VENDOR "OpenTelemetry")
 set(CPACK_PACKAGE_CONTACT "OpenTelemetry-cpp")
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://opentelemetry.io/")
 set(CMAKE_PROJECT_NAME "opentelemetry-cpp-geneva-metrics")
-set(OPENTELEMETRY_GENEVA_METRICS_VERSION "1.0.0")
+set(OPENTELEMETRY_GENEVA_METRICS_VERSION "1.0.1")
 
 option(TARBALL "Build a tarball package" OFF)
 

--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/socket_data_transport.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/socket_data_transport.h
@@ -14,18 +14,18 @@ OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter {
 namespace geneva {
 namespace metrics {
-class UnixDomainSocketDataTransport : public DataTransport {
+class SocketDataTransport : public DataTransport {
 public:
-  UnixDomainSocketDataTransport(const std::string &connection_string);
+  SocketDataTransport(const ConnectionStringParser &parser);
   bool Connect() noexcept override;
   bool Send(MetricsEventType event_type, const char *data,
             uint16_t length) noexcept override;
   bool Disconnect() noexcept override;
-  ~UnixDomainSocketDataTransport() = default;
+  ~SocketDataTransport() = default;
 
 private:
   // Socket connection is re-established for every batch of events
-  const SocketTools::SocketParams socketparams_{AF_UNIX, SOCK_STREAM, 0};
+  SocketTools::SocketParams socketparams_{AF_UNIX, SOCK_STREAM, 0};
   SocketTools::Socket socket_;
   std::unique_ptr<SocketTools::SocketAddr> addr_;
   bool connected_{false};

--- a/exporters/geneva/src/exporter.cc
+++ b/exporters/geneva/src/exporter.cc
@@ -6,7 +6,7 @@
 #ifdef _WIN32
 #include "opentelemetry/exporters/geneva/metrics/etw_data_transport.h"
 #else
-#include "opentelemetry/exporters/geneva/metrics/unix_domain_socket_data_transport.h"
+#include "opentelemetry/exporters/geneva/metrics/socket_data_transport.h"
 #endif
 #include "opentelemetry/sdk/metrics/export/metric_producer.h"
 #include "opentelemetry/sdk_config.h"
@@ -29,11 +29,12 @@ Exporter::Exporter(const ExporterOptions &options)
           new ETWDataTransport(kBinaryHeaderSize));
     }
 #else
-    if (connection_string_parser_.transport_protocol_ ==
-        TransportProtocol::kUNIX) {
+    if (connection_string_parser_.transport_protocol_ == TransportProtocol::kUNIX
+      || connection_string_parser_.transport_protocol_ == TransportProtocol::kTCP
+      || connection_string_parser_.transport_protocol_ == TransportProtocol::kUDP) {
       data_transport_ =
-          std::unique_ptr<DataTransport>(new UnixDomainSocketDataTransport(
-              connection_string_parser_.connection_string_));
+          std::unique_ptr<DataTransport>(new SocketDataTransport(
+              connection_string_parser_));
     }
 #endif
   }

--- a/exporters/geneva/src/socket_data_transport.cc
+++ b/exporters/geneva/src/socket_data_transport.cc
@@ -1,7 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include "opentelemetry/exporters/geneva/metrics/unix_domain_socket_data_transport.h"
+#include "opentelemetry/exporters/geneva/metrics/connection_string_parser.h"
+#include "opentelemetry/exporters/geneva/metrics/socket_data_transport.h"
 #include "opentelemetry/exporters/geneva/metrics/macros.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -9,13 +10,28 @@ namespace exporter {
 namespace geneva {
 namespace metrics {
 
-UnixDomainSocketDataTransport::UnixDomainSocketDataTransport(
-    const std::string &connection_string) 
+SocketDataTransport::SocketDataTransport(
+    const ConnectionStringParser &parser) 
 {      
-  addr_.reset(new SocketTools::SocketAddr(connection_string.c_str(), true));
+  bool is_unix_domain = false;
+
+  if (parser.transport_protocol_ == TransportProtocol::kTCP) {
+    socketparams_ = {AF_INET, SOCK_STREAM, 0};
+  }
+  else if (parser.transport_protocol_ == TransportProtocol::kUDP) {
+    socketparams_ = {AF_INET, SOCK_DGRAM, 0};
+  }
+  else if (parser.transport_protocol_ == TransportProtocol::kUNIX) {
+    socketparams_ = {AF_UNIX, SOCK_STREAM, 0};
+    is_unix_domain = true;
+  }
+  else {
+    LOG_ERROR("Geneva Exporter: Invalid transport protocol");
+  }
+  addr_.reset(new SocketTools::SocketAddr(parser.connection_string_.c_str(), is_unix_domain));
 }
 
-bool UnixDomainSocketDataTransport::Connect() noexcept {
+bool SocketDataTransport::Connect() noexcept {
   if (!connected_) {
     socket_ = SocketTools::Socket(socketparams_);
     connected_ = socket_.connect(*addr_);
@@ -27,7 +43,7 @@ bool UnixDomainSocketDataTransport::Connect() noexcept {
   return true;
 }
 
-bool UnixDomainSocketDataTransport::Send(MetricsEventType event_type,
+bool SocketDataTransport::Send(MetricsEventType event_type,
                                          char const *data,
                                          uint16_t length) noexcept {
   int error_code = 0;
@@ -58,7 +74,7 @@ bool UnixDomainSocketDataTransport::Send(MetricsEventType event_type,
   return true;
 }
 
-bool UnixDomainSocketDataTransport::Disconnect() noexcept {
+bool SocketDataTransport::Disconnect() noexcept {
   if (connected_) {
     connected_ = false;
     if (socket_.invalid()) {


### PR DESCRIPTION
## Description
This PR raised for fix #536 , navigate to the issue to get more details.

## Changes
* Add new `SocketDataTransport` to support UNIX/UDP/TCP protocol.
* Remove existing `UnixDomainDataTransport` since `SocketDataTransport` covered unix scenario.
* Update the version of `geneva-exporter` to `1.0.1`.

## Test && Validation
* Test in production scenarios.
* Passed the test cases.

## Existing Behavior
`exporter` only support `kETW` and `kUNIX` protocol although the connection string support `kUDP` and `kTCP`.

## New Behavior
Support all the protocols which defined in [TransportProtocol](https://github.com/open-telemetry/opentelemetry-cpp-contrib/blob/main/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/connection_string_parser.h#L22):
* kETW
* kUNIX
* kUDP (new added)
* kTCP (new added)

