### PR TITLE
[Geneva] Do not set shutdown on connection failure in initialization

### DIFF
--- a/exporters/geneva/src/exporter.cc
+++ b/exporters/geneva/src/exporter.cc
@@ -42,7 +42,6 @@ Exporter::Exporter(const ExporterOptions &options)
   auto status = data_transport_->Connect();
   if (!status) {
     LOG_ERROR("[Geneva Exporter] Connect failed. No data would be sent.");
-    is_shutdown_ = true;
     return;
   }
 }

--- a/exporters/geneva/src/socket_data_transport.cc
+++ b/exporters/geneva/src/socket_data_transport.cc
@@ -58,7 +58,7 @@ bool SocketDataTransport::Send(MetricsEventType event_type,
           "Geneva Exporter: UDS::Send Socket reconnect failed. Send failed");
     }
   }
-  if (error_code != 0) {
+  if (!connected_ || error_code != 0 ) {
     LOG_ERROR("Geneva Exporter: UDS::Send failed - not connected");
     connected_ = false;
     return false;


### PR DESCRIPTION
`is_shutdown` is set to true in the Geneva Exporter constructor which blocks further retry. It should be removed so that the exporter can retry. 