### PR TITLE
[Geneva] Send data to socket with MSG_NOSIGNAL

### DIFF
--- a/exporters/fluentd/include/opentelemetry/exporters/fluentd/common/socket_tools.h
+++ b/exporters/fluentd/include/opentelemetry/exporters/fluentd/common/socket_tools.h
@@ -585,8 +585,14 @@ struct Socket {
     assert(m_sock != Invalid);
     if ((m_sock == Invalid) || (buffer == nullptr) || (size == 0))
       return 0;
+    int flags =
+#ifdef _WIN32
+        0;
+#else
+        MSG_NOSIGNAL;
+#endif
     return static_cast<int>(
-        ::send(m_sock, reinterpret_cast<char const *>(buffer), size, 0));
+        ::send(m_sock, reinterpret_cast<char const *>(buffer), size, flags));
   }
 
   int sendto(void const *buffer, size_t size, int flags, SocketAddr &destAddr) {

--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/socket_tools.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/socket_tools.h
@@ -570,8 +570,14 @@ struct Socket {
     assert(m_sock != Invalid);
     if ((m_sock == Invalid) || (buffer == nullptr) || (size == 0))
       return 0;
+    int flags =
+#ifdef _WIN32
+        0;
+#else
+        MSG_NOSIGNAL;
+#endif
     return static_cast<int>(
-        ::send(m_sock, reinterpret_cast<char const *>(buffer), size, 0));
+        ::send(m_sock, reinterpret_cast<char const *>(buffer), size, flags));
   }
 
   int sendto(void const *buffer, size_t size, int flags, SocketAddr &destAddr) {


### PR DESCRIPTION
It is usually unexpected for the consumer application to receive SIGPIPE signal when the exporting target is closed, add `MSD_NOSIGNAL` flag to send to disable it.