### PR TITLE
POC: Possible implementation of opentelemetry-cpp-contrib cmake project with components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,76 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.14)
+
+project(opentelemetry-cpp-contrib VERSION 0.1.0 LANGUAGES CXX)
+
+# silence CMP0169 deprecation of one-arg Populate()
+cmake_policy(SET CMP0169 OLD)
+
+# Define options for each component in opentelemetry-cpp-contrib
+option(WITH_GENEVA "Build with Geneva exporters" ON)
+option(WITH_USER_EVENTS "Build with User Events exporters" ON)
+
+# Set the opentelemetry-cpp provider to use. 
+# - "fetch" will use the FetchContent module to download the opentelemetry-cpp repo and build in the same build tree
+# - "package" will find_package to import the installed opentelemetry-cpp package
+set(opentelemetry-cpp_PROVIDER "fetch" CACHE STRING "Provider for opentelemetry-cpp")
+set_property(CACHE opentelemetry-cpp_PROVIDER PROPERTY STRINGS "package" "fetch")
+
+set(OPENTELEMETRY_INSTALL OFF)
+set(OPENTELEMETRY_CONTRIB_INSTALL ON)
+
+include(CTest)
+include(GoogleTest)
+include(FetchContent)
+
+# Fetch opentelemetry-cpp: 
+#   This is required for the cmake install functions. 
+FetchContent_Declare(
+  opentelemetry-cpp
+  GIT_REPOSITORY
+  https://github.com/dbarker/opentelemetry-cpp.git
+  GIT_TAG
+  poc_otel_cmake_external_repo_support
+)
+# Alternatively fetch from an opentelemetry-cpp submodule
+# FetchContent_Declare(
+#  opentelemetry-cpp
+#  SOURCE_DIR "${PROJECT_SOURCE_DIR}/third_party/opentelemetry-cpp")
+
+if(opentelemetry-cpp_PROVIDER STREQUAL "package")
+  find_package(opentelemetry-cpp CONFIG REQUIRED)
+  FetchContent_Populate(opentelemetry-cpp)
+elseif(opentelemetry-cpp_PROVIDER STREQUAL "fetch")
+  if(WITH_USER_EVENTS)
+    # User Events needs the otlp_common component. Turn on one of the otlp components (There is no WITH_OTLP_COMMON option)
+    set(WITH_OTLP_FILE ON)
+  endif()
+
+  set(OPENTELEMETRY_INSTALL ON)
+
+  # Add opetelemetry-cpp to the build tree
+  FetchContent_MakeAvailable(opentelemetry-cpp)
+
+  if(WITH_ABI_VERSION_2)
+    set(OPENTELEMETRY_ABI_VERSION_NO "2")
+  elseif(WITH_ABI_VERSION_1)
+    set(OPENTELEMETRY_ABI_VERSION_NO "1")
+  endif()
+endif()
+
+# Include the opentelemetry-cpp cmake functions to support adding and installing components
+include(${opentelemetry-cpp_SOURCE_DIR}/cmake/otel-install-functions.cmake)
+
+# Add the contrib exporters components to the build tree
+add_subdirectory(exporters)
+
+# install the opentelemetry-cpp-contrib package
+if(OPENTELEMETRY_CONTRIB_INSTALL)
+  # Set the version for the opentelemetry-cpp-contrib package used in the config file template
+  set(OPENTELEMETRY_VERSION ${PROJECT_VERSION})
+  otel_install_cmake_config()
+  otel_install_components()
+  otel_install_thirdparty_definitions()
+endif() 

--- a/cmake/thirdparty-dependency-config.cmake
+++ b/cmake/thirdparty-dependency-config.cmake
@@ -1,0 +1,26 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+#-----------------------------------------------------------------------
+# Third party dependencies supported by opentelemetry-cpp-contrib
+# Dependencies that must be found with find_dependency() when a user calls find_package(opentelemetry-cpp-contrib ...)
+# should be included in this list.
+#-----------------------------------------------------------------------
+set(OTEL_THIRDPARTY_DEPENDENCIES_SUPPORTED
+     opentelemetry-cpp
+     tracepoint
+)
+
+#-----------------------------------------------------------------------
+# Third party dependency target namespaces. Defaults to the dependency's project name if not set.
+# Only set if the target namespace is different from the project name (these are case sensitive).
+# set(OTEL_<dependency>_TARGET_NAMESPACE "<namespace>")
+#-----------------------------------------------------------------------
+# set(OTEL_Protobuf_TARGET_NAMESPACE "protobuf")
+
+#-----------------------------------------------------------------------
+# Set the find_dependecy search mode - empty is default. Options: cmake default (empty string ""), "MODULE", or "CONFIG"
+# # set(OTEL_<dependency>_SEARCH_MODE "<search mode>")
+#-----------------------------------------------------------------------
+set(OTEL_opentelemetry-cpp_SEARCH_MODE "CONFIG")
+set(OTEL_tracepoint_SEARCH_MODE "CONFIG")

--- a/exporters/CMakeLists.txt
+++ b/exporters/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+if(WITH_GENEVA)
+  message(STATUS "Building with Geneva exporters")
+  add_subdirectory(geneva)
+endif() 
+
+if(WITH_USER_EVENTS)
+  message(STATUS "Building with User Events exporters")
+  add_subdirectory(user_events)
+endif()

--- a/exporters/geneva/CMakeLists.txt
+++ b/exporters/geneva/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
     
 add_definitions(-DHAVE_CONSOLE_LOG)
 if(MAIN_PROJECT)
-  find_package(opentelemetry-cpp REQUIRED)
+  find_package(opentelemetry-cpp REQUIRED COMPONENTS api sdk)
 endif()
 
 include_directories(include)
@@ -44,17 +44,12 @@ else()
               src/exporter.cc src/unix_domain_socket_data_transport.cc)
 endif()
 
-if(MAIN_PROJECT)
-   target_include_directories(opentelemetry_exporter_geneva_metrics
-                      PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS})
-   target_link_libraries(opentelemetry_exporter_geneva_metrics
-                      PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES})
-else()
-   target_link_libraries(opentelemetry_exporter_geneva_metrics
-                      PUBLIC opentelemetry_metrics opentelemetry_resources opentelemetry_common)
-endif()
+target_link_libraries(opentelemetry_exporter_geneva_metrics
+                      PUBLIC opentelemetry-cpp::metrics)
 
 set_target_version(opentelemetry_exporter_geneva_metrics)
+
+set_target_properties(opentelemetry_exporter_geneva_metrics PROPERTIES EXPORT_NAME geneva_metrics_exporter)
 
 if(BUILD_TESTING)
   if(EXISTS ${CMAKE_BINARY_DIR}/lib/libgtest.a)
@@ -90,7 +85,14 @@ if(BUILD_TESTING)
     TEST_LIST geneva_metrics_exporter_test)
 endif()
 
-if(OPENTELEMETRY_INSTALL)
+if(NOT MAIN_PROJECT)
+  otel_add_component(
+    COMPONENT exporters_geneva_metrics
+    TARGETS opentelemetry_exporter_geneva_metrics
+    FILES_DIRECTORY include/opentelemetry/exporters/geneva
+    FILES_DESTINATION include/opentelemetry/exporters
+    FILES_MATCHING PATTERN "*.h")
+elseif(OPENTELEMETRY_INSTALL)
   install(
     TARGETS opentelemetry_exporter_geneva_metrics
     EXPORT "${PROJECT_NAME}-target"
@@ -112,7 +114,7 @@ if(WITH_EXAMPLES)
 
   if(NOT WIN32)
     add_executable(stress_test_linux example/stress_test_linux.cc)
-    find_package(Boost QUIET)
+    find_package(Boost CONFIG QUIET)
     if(Boost_FOUND)
       include_directories(${Boost_INCLUDE_DIRS})
       target_compile_definitions(stress_test_linux PRIVATE HAVE_BOOST)

--- a/exporters/user_events/CMakeLists.txt
+++ b/exporters/user_events/CMakeLists.txt
@@ -8,12 +8,11 @@ option(WITH_EXAMPLES "Build example" ON)
 option(BUILD_TESTING "Build tests" ON)
 option(BUILD_TRACEPOINTS "Build tracepoints library" ON)
 
-project(opentelemetry-user_events-exporter)
+set(MAIN_PROJECT OFF)
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  project(opentelemetry-user_events-exporter)
   set(MAIN_PROJECT ON)
   message(STATUS "${PROJECT_NAME} is main project")
-else()
-  set(MAIN_PROJECT OFF)
 endif()
 
 if(MAIN_PROJECT)
@@ -21,7 +20,7 @@ if(MAIN_PROJECT)
   find_package(Protobuf REQUIRED)
   find_package(CURL REQUIRED)
   find_package(nlohmann_json REQUIRED)
-  find_package(opentelemetry-cpp REQUIRED)
+  find_package(opentelemetry-cpp CONFIG REQUIRED COMPONENTS api sdk exporters_otlp_common)
 endif()
 
 if(BUILD_TRACEPOINTS)
@@ -49,41 +48,27 @@ target_compile_features(opentelemetry_exporter_user_events_logs
 target_compile_definitions(opentelemetry_exporter_user_events_logs
                            PUBLIC HAVE_CONSOLE_LOG HAVE_LOGS_PREVIEW)
 
-if(MAIN_PROJECT)
-  target_include_directories(opentelemetry_exporter_user_events_logs
-                             PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS})
-  target_link_libraries(opentelemetry_exporter_user_events_logs
-                        PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES})
-else()
-  target_link_libraries(
+target_link_libraries(
     opentelemetry_exporter_user_events_logs
-    PUBLIC opentelemetry_logs opentelemetry_resources opentelemetry_common)
-endif()
+    PUBLIC opentelemetry-cpp::logs opentelemetry-cpp::version)
 
 target_link_libraries(opentelemetry_exporter_user_events_logs
                       PUBLIC eventheader-tracepoint tracepoint)
 
 set_target_properties(opentelemetry_exporter_user_events_logs
-                      PROPERTIES EXPORT_NAME logs)
+                      PROPERTIES EXPORT_NAME user_events_logs_exporter)
 
 add_library(opentelemetry_exporter_user_events_metrics src/metrics_exporter.cc)
 
 target_compile_features(opentelemetry_exporter_user_events_metrics
                         PRIVATE cxx_std_17)
 
-if(MAIN_PROJECT)
-  target_include_directories(opentelemetry_exporter_user_events_metrics
-                             PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS})
-  target_link_libraries(
+target_link_libraries(
     opentelemetry_exporter_user_events_metrics
-    PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES} tracepoint protobuf::libprotobuf)
-  # TODO: link to opentelemetry_otlp_recordable
-else()
-  target_link_libraries(
-    opentelemetry_exporter_user_events_metrics
-    PUBLIC opentelemetry_metrics opentelemetry_resources opentelemetry_common
-           opentelemetry_otlp_recordable tracepoint)
-endif()
+    PUBLIC opentelemetry-cpp::metrics opentelemetry-cpp::otlp_recordable tracepoint)
+
+set_target_properties(opentelemetry_exporter_user_events_metrics
+                  PROPERTIES EXPORT_NAME user_events_metrics_exporter)
 
 if(WITH_EXAMPLES)
   add_executable(user_events_logs example/logs/main.cc
@@ -136,15 +121,24 @@ if(WITH_BENCHMARK)
     opentelemetry_exporter_user_events_logs)
 endif()
 
-install(
-  TARGETS opentelemetry_exporter_user_events_logs
-  EXPORT "${PROJECT_NAME}-target"
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if(NOT MAIN_PROJECT)
+  otel_add_component(
+    COMPONENT exporters_user_events
+    TARGETS opentelemetry_exporter_user_events_logs opentelemetry_exporter_user_events_metrics
+    FILES_DIRECTORY include/opentelemetry/exporters/user_events
+    FILES_DESTINATION include/opentelemetry/exporters
+    FILES_MATCHING PATTERN "*.h")
+elseif(OPENTELEMETRY_INSTALL)
+  install(
+    TARGETS opentelemetry_exporter_user_events_logs
+    EXPORT "${PROJECT_NAME}-target"
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-install(
-  DIRECTORY include/opentelemetry/exporters/user_events
-  DESTINATION include/opentelemetry/exporters
-  FILES_MATCHING
-  PATTERN "*.h")
+  install(
+    DIRECTORY include/opentelemetry/exporters/user_events
+    DESTINATION include/opentelemetry/exporters
+    FILES_MATCHING
+    PATTERN "*.h")
+endif() 


### PR DESCRIPTION
This is a proof of concept for adding a top level CMakeLists.txt file to this repo in order to create a versioned `opentelemetry-cpp-contrib` package with components. 

Goals: 
1. Support building a separate versioned `opentelemetry-cpp-contrib` package that depends on `opentelmetry-cpp` 
2. Support two options for the `opentelemetry-cpp` dependency:
    - Option 1: Use `find_package` to import an installed `opentelemetry-cpp` package 
    - Option 2: Fetch `opentelemetry-cpp` from the git repo (or git submodule) and build it together with `opentelemetry-cpp-contrib` in a single build tree
3. Enable creating independent components for install and import with their own third party dependencies
   - Finding like so: `find_package(opentelemetry-cpp-contrib COMPONENTS exporters_geneva_metrics)`

This requires some minor changes to the `opentelemetry-cpp` cmake install functions for general use included in this branch. 
https://github.com/open-telemetry/opentelemetry-cpp/compare/main...dbarker:opentelemetry-cpp:poc_otel_cmake_external_repo_support 
 
Posting here for discussion. 
