### PR TITLE
[Geneva] Make EXPORT_NAME consistent

### DIFF
--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -117,6 +117,14 @@ if (WITH_EXAMPLES)
 endif()
 
 if(OPENTELEMETRY_INSTALL)
+  set_target_properties(
+    opentelemetry_exporter_geneva_trace
+    PROPERTIES
+      EXPORT_NAME opentelemetry_exporter_geneva_trace)
+  set_target_properties(
+    opentelemetry_exporter_geneva_logs
+    PROPERTIES
+      EXPORT_NAME opentelemetry_exporter_geneva_logs)
   if(MAIN_PROJECT)
     install(
       TARGETS opentelemetry_exporter_geneva_logs
@@ -132,14 +140,6 @@ if(OPENTELEMETRY_INSTALL)
       FILES_MATCHING
       PATTERN "*.h")
   else()
-    set_target_properties(
-      opentelemetry_exporter_geneva_trace
-      PROPERTIES
-        EXPORT_NAME opentelemetry_exporter_geneva_trace)
-    set_target_properties(
-      opentelemetry_exporter_geneva_logs
-      PROPERTIES
-        EXPORT_NAME opentelemetry_exporter_geneva_logs)
     otel_add_component(
       COMPONENT
       exporters_geneva_fluentd

--- a/exporters/geneva-trace/CMakeLists.txt
+++ b/exporters/geneva-trace/CMakeLists.txt
@@ -30,6 +30,13 @@ if(WITH_EXAMPLES)
 endif()
 
 if(OPENTELEMETRY_INSTALL)
+  set_target_properties(
+    opentelemetry_exporter_geneva_trace
+    PROPERTIES EXPORT_NAME opentelemetry_exporter_geneva_trace)
+  set_target_properties(
+    opentelemetry_exporter_geneva_logs
+    PROPERTIES EXPORT_NAME opentelemetry_exporter_geneva_logs)
+
   if(MAIN_PROJECT)
     install(DIRECTORY include/ DESTINATION include)
 
@@ -44,13 +51,6 @@ if(OPENTELEMETRY_INSTALL)
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
     endif()
   else()
-    set_target_properties(
-      opentelemetry_exporter_geneva_trace
-      PROPERTIES EXPORT_NAME opentelemetry_exporter_geneva_trace)
-    set_target_properties(
-      opentelemetry_exporter_geneva_logs
-      PROPERTIES EXPORT_NAME opentelemetry_exporter_geneva_logs)
-
     otel_add_component(
       COMPONENT
       exporters_geneva_trace_logs
@@ -60,7 +60,7 @@ if(OPENTELEMETRY_INSTALL)
       FILES_DIRECTORY
       "include/opentelemetry/exporters/geneva"
       FILES_DESTINATION
-      "include/opentelemetry/exporters/geneva"
+      "include/opentelemetry/exporters"
       FILES_MATCHING
       PATTERN
       "*.h")

--- a/exporters/geneva/CMakeLists.txt
+++ b/exporters/geneva/CMakeLists.txt
@@ -91,40 +91,36 @@ if(BUILD_TESTING)
 endif()
 
 if(OPENTELEMETRY_INSTALL)
-
-if(MAIN_PROJECT)
-
-  install(
-    TARGETS opentelemetry_exporter_geneva_metrics
-    EXPORT "${PROJECT_NAME}-target"
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
-  install(
-    DIRECTORY include/opentelemetry/exporters/geneva
-    DESTINATION include/opentelemetry/exporters
-    FILES_MATCHING
-    PATTERN "*.h")
-
-else()
-
-  set_target_properties(opentelemetry_exporter_geneva_metrics PROPERTIES EXPORT_NAME opentelemetry_exporter_geneva_metrics)
-
-  otel_add_component(
-    COMPONENT
-    exporters_geneva_metrics
-    TARGETS
+  set_targt_properties(
     opentelemetry_exporter_geneva_metrics
-    FILES_DIRECTORY
-    "include/opentelemetry/exporters/geneva"
-    FILES_DESTINATION
-    "include/opentelemetry/exporters"
-    FILES_MATCHING
-    PATTERN
-    "*.h")
+    PROPERTIES EXPORT_NAME opentelemetry_exporter_geneva_metrics)
+  if(MAIN_PROJECT)
+    install(
+      TARGETS opentelemetry_exporter_geneva_metrics
+      EXPORT "${PROJECT_NAME}-target"
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-endif()
+    install(
+      DIRECTORY include/opentelemetry/exporters/geneva
+      DESTINATION include/opentelemetry/exporters
+      FILES_MATCHING
+      PATTERN "*.h")
+  else()
+    otel_add_component(
+      COMPONENT
+      exporters_geneva_metrics
+      TARGETS
+      opentelemetry_exporter_geneva_metrics
+      FILES_DIRECTORY
+      "include/opentelemetry/exporters/geneva"
+      FILES_DESTINATION
+      "include/opentelemetry/exporters"
+      FILES_MATCHING
+      PATTERN
+      "*.h")
+  endif()
 endif()
 
 if(WITH_EXAMPLES)

--- a/exporters/user_events/CMakeLists.txt
+++ b/exporters/user_events/CMakeLists.txt
@@ -136,29 +136,29 @@ if(WITH_BENCHMARK)
     opentelemetry_exporter_user_events_logs)
 endif()
 
+set_target_properties(
+  opentelemetry_exporter_user_events_logs
+  PROPERTIES
+    EXPORT_NAME opentelemetry_exporter_user_events_logs)
+set_target_properties(
+  opentelemetry_exporter_user_events_metrics
+  PROPERTIES
+    EXPORT_NAME opentelemetry_exporter_user_events_metrics)
+
 if(MAIN_PROJECT)
+  install(
+    TARGETS opentelemetry_exporter_user_events_logs
+    EXPORT "${PROJECT_NAME}-target"
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-install(
-  TARGETS opentelemetry_exporter_user_events_logs
-  EXPORT "${PROJECT_NAME}-target"
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
-install(
-  DIRECTORY include/opentelemetry/exporters/user_events
-  DESTINATION include/opentelemetry/exporters
-  FILES_MATCHING
-  PATTERN "*.h")
+  install(
+    DIRECTORY include/opentelemetry/exporters/user_events
+    DESTINATION include/opentelemetry/exporters
+    FILES_MATCHING
+    PATTERN "*.h")
 else()
-  set_target_properties(
-    opentelemetry_exporter_user_events_logs
-    PROPERTIES
-      EXPORT_NAME opentelemetry_exporter_user_events_logs)
-  set_target_properties(
-    opentelemetry_exporter_user_events_metrics
-    PROPERTIES
-      EXPORT_NAME opentelemetry_exporter_user_events_metrics)
   otel_add_component(
     COMPONENT
     exporters_user_events


### PR DESCRIPTION
Address the commend on inconsistent EXPORT_NAME for different build types of the contrib exportes.