### PR TITLE
Nginx version upgrade to 1.28 (stable) and 1.27.5 (mainline) for webserver-sdk

### DIFF
--- a/instrumentation/otel-webserver-module/Dockerfile
+++ b/instrumentation/otel-webserver-module/Dockerfile
@@ -24,7 +24,7 @@ ARG LOG4CXX_VERSION="0.11.0"
 ARG GTEST_VERSION="1.10.0"
 ARG AUTOMAKE_VERSION="1.16.3"
 ARG PCRE_VERSION="8.44"
-ARG NGINX_VERSION="1.27.3"
+ARG NGINX_VERSION="1.28.0"
 
 
 # create default non-root user
@@ -273,7 +273,7 @@ RUN cd /otel-webserver-module/build \
     && cd /
 
 RUN cp /otel-webserver-module/conf/nginx/opentelemetry_module.conf /opt/ \
-    && sed -i '8i load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/1.27.3/ngx_http_opentelemetry_module.so;' /etc/nginx/nginx.conf \
+    && sed -i '8i load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/1.28.0/ngx_http_opentelemetry_module.so;' /etc/nginx/nginx.conf \
     && sed -i '33i include /opt/opentelemetry_module.conf;' /etc/nginx/nginx.conf \ 
     && cd /
 

--- a/instrumentation/otel-webserver-module/Dockerfile
+++ b/instrumentation/otel-webserver-module/Dockerfile
@@ -24,7 +24,7 @@ ARG LOG4CXX_VERSION="0.11.0"
 ARG GTEST_VERSION="1.10.0"
 ARG AUTOMAKE_VERSION="1.16.3"
 ARG PCRE_VERSION="8.44"
-ARG NGINX_VERSION="1.26.0"
+ARG NGINX_VERSION="1.27.3"
 
 
 # create default non-root user
@@ -273,7 +273,7 @@ RUN cd /otel-webserver-module/build \
     && cd /
 
 RUN cp /otel-webserver-module/conf/nginx/opentelemetry_module.conf /opt/ \
-    && sed -i '8i load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/1.26.0/ngx_http_opentelemetry_module.so;' /etc/nginx/nginx.conf \
+    && sed -i '8i load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/1.27.3/ngx_http_opentelemetry_module.so;' /etc/nginx/nginx.conf \
     && sed -i '33i include /opt/opentelemetry_module.conf;' /etc/nginx/nginx.conf \ 
     && cd /
 

--- a/instrumentation/otel-webserver-module/README.md
+++ b/instrumentation/otel-webserver-module/README.md
@@ -191,7 +191,7 @@ Currently, Nginx Webserver module monitores some fixed set of modules, which get
 - Docker Desktop should be installed on the system
 
 #### Platform Supported
-- Supports both stable(1.26.0) and mainline(1.25.5).
+- Supports both stable(1.28.0) and mainline(1.27.3).
 - Earlier support of v1.18.0 is deprecated.
 - The build is supported for **x86-64** platforms.
 - OS support: **Centos7, Almalinux8, ubuntu20.04**.

--- a/instrumentation/otel-webserver-module/README.md
+++ b/instrumentation/otel-webserver-module/README.md
@@ -150,7 +150,7 @@ Currently, Nginx Webserver module monitores some fixed set of modules, which get
 
 | Library                                        | Present Version |
 | ---------------------------------------------- | -----------     |
-| Nginx                                          | 1.26.0, 1.25.5          |
+| Nginx                                          | 1.28.0, 1.27.5          |
 | Apr                                            | 1.7.0           |
 | Apr-util                                       | 1.6.1           |
 
@@ -191,7 +191,7 @@ Currently, Nginx Webserver module monitores some fixed set of modules, which get
 - Docker Desktop should be installed on the system
 
 #### Platform Supported
-- Supports both stable(1.28.0) and mainline(1.27.3).
+- Supports both stable(1.28.0) and mainline(1.27.5).
 - Earlier support of v1.18.0 is deprecated.
 - The build is supported for **x86-64** platforms.
 - OS support: **Centos7, Almalinux8, ubuntu20.04**.

--- a/instrumentation/otel-webserver-module/codeql-env.sh
+++ b/instrumentation/otel-webserver-module/codeql-env.sh
@@ -36,7 +36,7 @@ APRUTIL_VERSION="1.6.1"
 LOG4CXX_VERSION="0.11.0"
 GTEST_VERSION="1.10.0"
 PCRE_VERSION="8.44"
-NGINX_VERSION="1.27.3"
+NGINX_VERSION="1.28.0"
 
 # Install GRPC
 git clone --shallow-submodules --depth 1 --recurse-submodules -b v${GRPC_VERSION} \

--- a/instrumentation/otel-webserver-module/codeql-env.sh
+++ b/instrumentation/otel-webserver-module/codeql-env.sh
@@ -36,7 +36,7 @@ APRUTIL_VERSION="1.6.1"
 LOG4CXX_VERSION="0.11.0"
 GTEST_VERSION="1.10.0"
 PCRE_VERSION="8.44"
-NGINX_VERSION="1.26.2"
+NGINX_VERSION="1.27.3"
 
 # Install GRPC
 git clone --shallow-submodules --depth 1 --recurse-submodules -b v${GRPC_VERSION} \

--- a/instrumentation/otel-webserver-module/docker/almalinux8/Dockerfile
+++ b/instrumentation/otel-webserver-module/docker/almalinux8/Dockerfile
@@ -26,7 +26,7 @@ ARG AUTOMAKE_VERSION="1.16.3"
 ARG PERL_VERSION="5.20.2"
 ARG PERL_CPANVERSION="5.0"
 ARG PCRE_VERSION="8.44"
-ARG NGINX_VERSION="1.26.0"
+ARG NGINX_VERSION="1.27.3"
 
 # create default non-root user
 RUN groupadd -r swuser && useradd -u 1000 -g swuser -m -s /sbin/nologin -c "default non-root user" swuser

--- a/instrumentation/otel-webserver-module/docker/almalinux8/Dockerfile
+++ b/instrumentation/otel-webserver-module/docker/almalinux8/Dockerfile
@@ -26,7 +26,7 @@ ARG AUTOMAKE_VERSION="1.16.3"
 ARG PERL_VERSION="5.20.2"
 ARG PERL_CPANVERSION="5.0"
 ARG PCRE_VERSION="8.44"
-ARG NGINX_VERSION="1.27.3"
+ARG NGINX_VERSION="1.28.0"
 
 # create default non-root user
 RUN groupadd -r swuser && useradd -u 1000 -g swuser -m -s /sbin/nologin -c "default non-root user" swuser

--- a/instrumentation/otel-webserver-module/docker/centos7/Dockerfile
+++ b/instrumentation/otel-webserver-module/docker/centos7/Dockerfile
@@ -26,7 +26,7 @@ ARG AUTOMAKE_VERSION="1.16.3"
 ARG PERL_VERSION="5.20.2"
 ARG PERL_CPANVERSION="5.0"
 ARG PCRE_VERSION="8.44"
-ARG NGINX_VERSION="1.27.3"
+ARG NGINX_VERSION="1.28.0"
 
 # create default non-root user
 RUN groupadd -r swuser && useradd -u 1000 -g swuser -m -s /sbin/nologin -c "default non-root user" swuser
@@ -292,7 +292,7 @@ RUN cd /otel-webserver-module/build \
     && cd /
 
 RUN cp /otel-webserver-module/conf/nginx/opentelemetry_module.conf /opt/ \
-    && sed -i '8i load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/1.27.3/ngx_http_opentelemetry_module.so;' /etc/nginx/nginx.conf \
+    && sed -i '8i load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/1.28.0/ngx_http_opentelemetry_module.so;' /etc/nginx/nginx.conf \
     && sed -i '33i include /opt/opentelemetry_module.conf;' /etc/nginx/nginx.conf \ 
     && cd /
 

--- a/instrumentation/otel-webserver-module/docker/centos7/Dockerfile
+++ b/instrumentation/otel-webserver-module/docker/centos7/Dockerfile
@@ -26,7 +26,7 @@ ARG AUTOMAKE_VERSION="1.16.3"
 ARG PERL_VERSION="5.20.2"
 ARG PERL_CPANVERSION="5.0"
 ARG PCRE_VERSION="8.44"
-ARG NGINX_VERSION="1.26.0"
+ARG NGINX_VERSION="1.27.3"
 
 # create default non-root user
 RUN groupadd -r swuser && useradd -u 1000 -g swuser -m -s /sbin/nologin -c "default non-root user" swuser
@@ -292,7 +292,7 @@ RUN cd /otel-webserver-module/build \
     && cd /
 
 RUN cp /otel-webserver-module/conf/nginx/opentelemetry_module.conf /opt/ \
-    && sed -i '8i load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/1.26.0/ngx_http_opentelemetry_module.so;' /etc/nginx/nginx.conf \
+    && sed -i '8i load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/1.27.3/ngx_http_opentelemetry_module.so;' /etc/nginx/nginx.conf \
     && sed -i '33i include /opt/opentelemetry_module.conf;' /etc/nginx/nginx.conf \ 
     && cd /
 

--- a/instrumentation/otel-webserver-module/docker/ubuntu20.04/Dockerfile
+++ b/instrumentation/otel-webserver-module/docker/ubuntu20.04/Dockerfile
@@ -38,7 +38,7 @@ ARG APRUTIL_VERSION="1.6.1"
 ARG LOG4CXX_VERSION="0.11.0"
 ARG GTEST_VERSION="1.10.0"
 ARG PCRE_VERSION="8.44"
-ARG NGINX_VERSION="1.26.0"
+ARG NGINX_VERSION="1.27.3"
 
 # Install GRPC
 RUN git clone --shallow-submodules --depth 1 --recurse-submodules -b v${GRPC_VERSION} \
@@ -213,7 +213,7 @@ RUN cd /otel-webserver-module/build \
 
 RUN cd /otel-webserver-module/build \
     && cp ../conf/nginx/opentelemetry_module.conf /opt/ \
-    && sed -i '5i load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/1.26.0/ngx_http_opentelemetry_module.so;' /etc/nginx/nginx.conf \
+    && sed -i '5i load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/1.27.3/ngx_http_opentelemetry_module.so;' /etc/nginx/nginx.conf \
     && sed -i '33i include /opt/opentelemetry_module.conf;' /etc/nginx/nginx.conf \
     && cd /opt/opentelemetry-webserver-sdk \
     && ./install.sh \

--- a/instrumentation/otel-webserver-module/docker/ubuntu20.04/Dockerfile
+++ b/instrumentation/otel-webserver-module/docker/ubuntu20.04/Dockerfile
@@ -38,7 +38,7 @@ ARG APRUTIL_VERSION="1.6.1"
 ARG LOG4CXX_VERSION="0.11.0"
 ARG GTEST_VERSION="1.10.0"
 ARG PCRE_VERSION="8.44"
-ARG NGINX_VERSION="1.27.3"
+ARG NGINX_VERSION="1.28.0"
 
 # Install GRPC
 RUN git clone --shallow-submodules --depth 1 --recurse-submodules -b v${GRPC_VERSION} \
@@ -213,7 +213,7 @@ RUN cd /otel-webserver-module/build \
 
 RUN cd /otel-webserver-module/build \
     && cp ../conf/nginx/opentelemetry_module.conf /opt/ \
-    && sed -i '5i load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/1.27.3/ngx_http_opentelemetry_module.so;' /etc/nginx/nginx.conf \
+    && sed -i '5i load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/1.28.0/ngx_http_opentelemetry_module.so;' /etc/nginx/nginx.conf \
     && sed -i '33i include /opt/opentelemetry_module.conf;' /etc/nginx/nginx.conf \
     && cd /opt/opentelemetry-webserver-sdk \
     && ./install.sh \

--- a/instrumentation/otel-webserver-module/version.properties
+++ b/instrumentation/otel-webserver-module/version.properties
@@ -1,4 +1,4 @@
 server-module-version=1.0.3
 release=GA
-nginxSupportedVersions=1.28.0,1.27.3
+nginxSupportedVersions=1.28.0,1.27.5
 CPP-SDK-version=1.2.0

--- a/instrumentation/otel-webserver-module/version.properties
+++ b/instrumentation/otel-webserver-module/version.properties
@@ -1,4 +1,4 @@
 server-module-version=1.0.3
 release=GA
-nginxSupportedVersions=1.26.0,1.25.5
+nginxSupportedVersions=1.28.0,1.27.3
 CPP-SDK-version=1.2.0


### PR DESCRIPTION
Changes for the webserver-sdk to support newer nginx versions (1.28-stable and 1.27.5-mainline).