### PR TITLE
Fix exporter/user_events build and installation as external component for opentelemetry-cpp

### DIFF
--- a/exporters/user_events/CMakeLists.txt
+++ b/exporters/user_events/CMakeLists.txt
@@ -8,12 +8,12 @@ option(WITH_EXAMPLES "Build example" ON)
 option(BUILD_TESTING "Build tests" ON)
 option(BUILD_TRACEPOINTS "Build tracepoints library" ON)
 
-project(opentelemetry-user_events-exporter)
+set(MAIN_PROJECT OFF)
+
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(MAIN_PROJECT ON)
+  project(opentelemetry-user_events-exporter)
   message(STATUS "${PROJECT_NAME} is main project")
-else()
-  set(MAIN_PROJECT OFF)
 endif()
 
 if(MAIN_PROJECT)


### PR DESCRIPTION
This pull request updates the logic in `exporters/user_events/CMakeLists.txt` to ensure that the `project(opentelemetry-user_events-exporter)` declaration only occurs when the CMake file is the main project. This change helps prevent issues when including this exporter as a subproject in opentelemetry-cpp build. 

The project() command changes the PROJECT_SOURCE_DIR variable, which is used for the scope of the external components list variable in opentelemetry-cpp. This causes the user_events to be registered in the wrong list, and installation fails to install lib and include files.

Build system improvements:

* Moved the `project(opentelemetry-user_events-exporter)` declaration inside the main project check to avoid redefining the project when included as a subproject.