### PR TITLE
Remove units parameter for Metrics::View in user_events and geneva examples

### DIFF
--- a/.github/workflows/geneva_metrics.yml
+++ b/.github/workflows/geneva_metrics.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.22.0"
+          ref: "v1.23.0"
           path: "otel_cpp"
           submodules: "recursive"
       - name: setup

--- a/.github/workflows/geneva_metrics.yml
+++ b/.github/workflows/geneva_metrics.yml
@@ -36,7 +36,9 @@ jobs:
             ca-certificates wget git valgrind lcov
       - name: run tests
         run: |
-          sudo $GITHUB_WORKSPACE/otel_cpp/ci/install_thirdparty.sh --install-dir /usr/local --tags-file third_party_release --packages "googletest;benchmark"
+          pushd "$GITHUB_WORKSPACE/otel_cpp"
+          sudo ./ci/install_thirdparty.sh --install-dir /usr/local --tags-file third_party_release --packages "googletest;benchmark"
+          popd
           mkdir -p "$GITHUB_WORKSPACE/otel_cpp/build"
           cd "$GITHUB_WORKSPACE/otel_cpp/build"
           cmake .. -DOPENTELEMETRY_INSTALL=ON

--- a/.github/workflows/geneva_metrics.yml
+++ b/.github/workflows/geneva_metrics.yml
@@ -36,7 +36,7 @@ jobs:
             ca-certificates wget git valgrind lcov
       - name: run tests
         run: |
-          sudo $GITHUB_WORKSPACE/otel_cpp/ci/setup_googletest.sh
+          sudo $GITHUB_WORKSPACE/otel_cpp/ci/install_thirdparty.sh --install-dir /usr/local --tags-file third_party_release --packages "googletest;benchmark"
           mkdir -p "$GITHUB_WORKSPACE/otel_cpp/build"
           cd "$GITHUB_WORKSPACE/otel_cpp/build"
           cmake .. -DOPENTELEMETRY_INSTALL=ON

--- a/.github/workflows/user_events.yml
+++ b/.github/workflows/user_events.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "open-telemetry/opentelemetry-cpp"
-          ref: "v1.21.0"
+          ref: "v1.23.0"
           path: "opentelemetry-cpp"
           submodules: "recursive"
       - name: setup dependencies

--- a/.github/workflows/user_events.yml
+++ b/.github/workflows/user_events.yml
@@ -50,7 +50,9 @@ jobs:
 
       - name: run tests
         run: |
-          sudo $GITHUB_WORKSPACE/opentelemetry-cpp/ci/install_thirdparty.sh --install-dir /usr/local --tags-file third_party_release --packages "googletest;benchmark"
+          pushd "$GITHUB_WORKSPACE/opentelemetry-cpp"
+          sudo ./ci/install_thirdparty.sh --install-dir /usr/local --tags-file third_party_release --packages "googletest;benchmark"
+          popd
           mkdir -p "$GITHUB_WORKSPACE/opentelemetry-cpp/build"
           cd "$GITHUB_WORKSPACE/opentelemetry-cpp/build"
           cmake .. -G Ninja -D OPENTELEMETRY_EXTERNAL_COMPONENT_PATH=$GITHUB_WORKSPACE/opentelemetry-cpp-contrib/exporters/user_events -D WITH_OTLP_HTTP=ON

--- a/.github/workflows/user_events.yml
+++ b/.github/workflows/user_events.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: run tests
         run: |
-          sudo $GITHUB_WORKSPACE/opentelemetry-cpp/ci/setup_googletest.sh
+          sudo $GITHUB_WORKSPACE/opentelemetry-cpp/ci/install_thirdparty.sh --install-dir /usr/local --tags-file third_party_release --packages "googletest;benchmark"
           mkdir -p "$GITHUB_WORKSPACE/opentelemetry-cpp/build"
           cd "$GITHUB_WORKSPACE/opentelemetry-cpp/build"
           cmake .. -G Ninja -D OPENTELEMETRY_EXTERNAL_COMPONENT_PATH=$GITHUB_WORKSPACE/opentelemetry-cpp-contrib/exporters/user_events -D WITH_OTLP_HTTP=ON

--- a/exporters/geneva/example/example_metrics.cc
+++ b/exporters/geneva/example/example_metrics.cc
@@ -57,7 +57,7 @@ void initMetrics(const std::string &name, const std::string &account_name) {
   std::unique_ptr<metric_sdk::MeterSelector> meter_selector{
       new metric_sdk::MeterSelector(name, version, schema)};
   std::unique_ptr<metric_sdk::View> sum_view{new metric_sdk::View{
-      name, "description", "", metric_sdk::AggregationType::kSum}};
+      name, "description", metric_sdk::AggregationType::kSum}};
   p->AddView(std::move(instrument_selector), std::move(meter_selector),
              std::move(sum_view));
 
@@ -70,7 +70,7 @@ void initMetrics(const std::string &name, const std::string &account_name) {
   std::unique_ptr<metric_sdk::MeterSelector> observable_meter_selector{
       new metric_sdk::MeterSelector(name, version, schema)};
   std::unique_ptr<metric_sdk::View> observable_sum_view{new metric_sdk::View{
-      name, "description", "", metric_sdk::AggregationType::kSum}};
+      name, "description", metric_sdk::AggregationType::kSum}};
   p->AddView(std::move(observable_instrument_selector),
              std::move(observable_meter_selector),
              std::move(observable_sum_view));
@@ -90,7 +90,7 @@ void initMetrics(const std::string &name, const std::string &account_name) {
       ->boundaries_ = std::vector<double>{0.0,   50.0,   100.0,  250.0,  500.0,
                                         750.0, 1000.0, 2500.0, 5000.0, 10000.0};
   std::unique_ptr<metric_sdk::View> histogram_view{new metric_sdk::View{
-      name, "description", "", metric_sdk::AggregationType::kHistogram,
+      name, "description", metric_sdk::AggregationType::kHistogram,
       aggregation_config}};
   p->AddView(std::move(histogram_instrument_selector),
              std::move(histogram_meter_selector), std::move(histogram_view));

--- a/exporters/user_events/example/metrics/main.cc
+++ b/exporters/user_events/example/metrics/main.cc
@@ -51,7 +51,7 @@ void initMetrics(const std::string &name, const std::string &account_name) {
   std::unique_ptr<metric_sdk::MeterSelector> meter_selector{
       new metric_sdk::MeterSelector(name, version, schema)};
   std::unique_ptr<metric_sdk::View> sum_view{new metric_sdk::View{
-      name, "description", instrument_unit, metric_sdk::AggregationType::kSum}};
+      name, "description", metric_sdk::AggregationType::kSum}};
   p->AddView(std::move(instrument_selector), std::move(meter_selector),
              std::move(sum_view));
 
@@ -64,7 +64,7 @@ void initMetrics(const std::string &name, const std::string &account_name) {
   std::unique_ptr<metric_sdk::MeterSelector> observable_meter_selector{
       new metric_sdk::MeterSelector(name, version, schema)};
   std::unique_ptr<metric_sdk::View> observable_sum_view{new metric_sdk::View{
-      name, "description", instrument_unit, metric_sdk::AggregationType::kSum}};
+      name, "description", metric_sdk::AggregationType::kSum}};
   p->AddView(std::move(observable_instrument_selector),
              std::move(observable_meter_selector),
              std::move(observable_sum_view));
@@ -84,7 +84,7 @@ void initMetrics(const std::string &name, const std::string &account_name) {
       ->boundaries_ = std::vector<double>{0.0,   50.0,   100.0,  250.0,  500.0,
                                         750.0, 1000.0, 2500.0, 5000.0, 10000.0};
   std::unique_ptr<metric_sdk::View> histogram_view{new metric_sdk::View{
-      name, "description", instrument_unit, metric_sdk::AggregationType::kHistogram,
+      name, "description", metric_sdk::AggregationType::kHistogram,
       aggregation_config}};
   p->AddView(std::move(histogram_instrument_selector),
              std::move(histogram_meter_selector), std::move(histogram_view));


### PR DESCRIPTION
This change fixes the examples in user_events and geneva exporters. OpenTelemetry-cpp v1.23.0 removed unit parameter from Metrics::View constructor.
Upgraded opentelemetry-cpp to v1.23.0 in tests.
Change setup of google test since setup_googletest.sh script is removed in opentelemetry-cpp.