### PR TITLE
resolve socket leak in fluentd exporter

### DIFF
--- a/exporters/fluentd/src/log/fluentd_exporter.cc
+++ b/exporters/fluentd/src/log/fluentd_exporter.cc
@@ -173,7 +173,6 @@ bool FluentdExporter::Connect() {
       if (!socket_.invalid()) {
         socket_.close();
       }
-      connected_ = false;
       return false;
     }
   }


### PR DESCRIPTION
fluentd_exporter.cc Connect() function is causing socket leak when the connection fails.

Test results: Open FDs count stopped increasing after fix.
=================
```
Every 2.0s: /workspace/pid_watch.sh                                                                qemux86-64: Fri Oct  3 20:15:02 2025

Time: 2025-10-03 20:15:02  PID: 1827
---- /proc/1827/limits ----
Limit                     Soft Limit           Hard Limit           Units
Max open files            1024                 4096                 files
---- FD usage ----
open_fds: 11  max_fds: 1024 4096
---- Socket counts (tcp/udp/unix) ----
tcp lines: 14
udp lines: 4
unix lines: 11
```

```
Every 2.0s: /workspace/pid_watch.sh                                                                  qemux86-64: Fri Oct  3 20:16:59 2025

Time: 2025-10-03 20:16:59  PID: 1827
---- /proc/1827/limits ----
Limit                     Soft Limit           Hard Limit           Units
Max open files            1024                 4096                 files

---- FD usage ----
open_fds: 11  max_fds: 1024 4096
---- Socket counts (tcp/udp/unix) ----
tcp lines: 14
udp lines: 4
unix lines: 11
```