### PR TITLE
Fix ODR violation when using Geneva logs and metrics exporters together on Linux

### DIFF
--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/socket_tools.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/socket_tools.h
@@ -111,8 +111,12 @@ typedef u_short sa_family_t;
 
 #include "opentelemetry/exporters/geneva/metrics/macros.h"
 
-// Wrap in geneva_metrics namespace to avoid ODR violations with fluentd socket_tools.h
-namespace geneva_metrics {
+// Wrap in detail namespace to avoid ODR violations with fluentd socket_tools.h
+namespace opentelemetry {
+namespace exporter {
+namespace geneva {
+namespace metrics {
+namespace detail {
 
 namespace net {
 
@@ -1133,7 +1137,11 @@ public:
 
 } // namespace SocketTools
 
-} // namespace geneva_metrics
+} // namespace detail
+} // namespace metrics
+} // namespace geneva
+} // namespace exporter
+} // namespace opentelemetry
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/socket_tools.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/socket_tools.h
@@ -110,9 +110,10 @@ typedef u_short sa_family_t;
 #endif
 
 #include "opentelemetry/exporters/geneva/metrics/macros.h"
+#include "opentelemetry/version.h"
 
 // Wrap in detail namespace to avoid ODR violations with fluentd socket_tools.h
-namespace opentelemetry {
+OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter {
 namespace geneva {
 namespace metrics {
@@ -1141,7 +1142,7 @@ public:
 } // namespace metrics
 } // namespace geneva
 } // namespace exporter
-} // namespace opentelemetry
+OPENTELEMETRY_END_NAMESPACE
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/socket_tools.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/socket_tools.h
@@ -111,6 +111,9 @@ typedef u_short sa_family_t;
 
 #include "opentelemetry/exporters/geneva/metrics/macros.h"
 
+// Wrap in geneva_metrics namespace to avoid ODR violations with fluentd socket_tools.h
+namespace geneva_metrics {
+
 namespace net {
 
 /// <summary>
@@ -1129,6 +1132,8 @@ public:
 };
 
 } // namespace SocketTools
+
+} // namespace geneva_metrics
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/unix_domain_socket_data_transport.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/unix_domain_socket_data_transport.h
@@ -14,6 +14,10 @@ OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter {
 namespace geneva {
 namespace metrics {
+
+// Use geneva_metrics namespace for socket tools to avoid conflicts with fluentd
+using namespace geneva_metrics;
+
 class UnixDomainSocketDataTransport : public DataTransport {
 public:
   UnixDomainSocketDataTransport(const std::string &connection_string);

--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/unix_domain_socket_data_transport.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/unix_domain_socket_data_transport.h
@@ -26,9 +26,9 @@ public:
 
 private:
   // Socket connection is re-established for every batch of events
-  const ::opentelemetry::exporter::geneva::metrics::detail::SocketTools::SocketParams socketparams_{AF_UNIX, SOCK_STREAM, 0};
-  ::opentelemetry::exporter::geneva::metrics::detail::SocketTools::Socket socket_;
-  std::unique_ptr<::opentelemetry::exporter::geneva::metrics::detail::SocketTools::SocketAddr> addr_;
+  const detail::SocketTools::SocketParams socketparams_{AF_UNIX, SOCK_STREAM, 0};
+  detail::SocketTools::Socket socket_;
+  std::unique_ptr<detail::SocketTools::SocketAddr> addr_;
   bool connected_{false};
 };
 } // namespace metrics

--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/unix_domain_socket_data_transport.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/unix_domain_socket_data_transport.h
@@ -26,9 +26,9 @@ public:
 
 private:
   // Socket connection is re-established for every batch of events
-  const geneva_metrics::SocketTools::SocketParams socketparams_{AF_UNIX, SOCK_STREAM, 0};
-  geneva_metrics::SocketTools::Socket socket_;
-  std::unique_ptr<geneva_metrics::SocketTools::SocketAddr> addr_;
+  const detail::SocketTools::SocketParams socketparams_{AF_UNIX, SOCK_STREAM, 0};
+  detail::SocketTools::Socket socket_;
+  std::unique_ptr<detail::SocketTools::SocketAddr> addr_;
   bool connected_{false};
 };
 } // namespace metrics

--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/unix_domain_socket_data_transport.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/unix_domain_socket_data_transport.h
@@ -15,9 +15,6 @@ namespace exporter {
 namespace geneva {
 namespace metrics {
 
-// Use geneva_metrics namespace for socket tools to avoid conflicts with fluentd
-using namespace geneva_metrics;
-
 class UnixDomainSocketDataTransport : public DataTransport {
 public:
   UnixDomainSocketDataTransport(const std::string &connection_string);
@@ -29,9 +26,9 @@ public:
 
 private:
   // Socket connection is re-established for every batch of events
-  const SocketTools::SocketParams socketparams_{AF_UNIX, SOCK_STREAM, 0};
-  SocketTools::Socket socket_;
-  std::unique_ptr<SocketTools::SocketAddr> addr_;
+  const geneva_metrics::SocketTools::SocketParams socketparams_{AF_UNIX, SOCK_STREAM, 0};
+  geneva_metrics::SocketTools::Socket socket_;
+  std::unique_ptr<geneva_metrics::SocketTools::SocketAddr> addr_;
   bool connected_{false};
 };
 } // namespace metrics

--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/unix_domain_socket_data_transport.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/unix_domain_socket_data_transport.h
@@ -26,9 +26,9 @@ public:
 
 private:
   // Socket connection is re-established for every batch of events
-  const detail::SocketTools::SocketParams socketparams_{AF_UNIX, SOCK_STREAM, 0};
-  detail::SocketTools::Socket socket_;
-  std::unique_ptr<detail::SocketTools::SocketAddr> addr_;
+  const ::opentelemetry::exporter::geneva::metrics::detail::SocketTools::SocketParams socketparams_{AF_UNIX, SOCK_STREAM, 0};
+  ::opentelemetry::exporter::geneva::metrics::detail::SocketTools::Socket socket_;
+  std::unique_ptr<::opentelemetry::exporter::geneva::metrics::detail::SocketTools::SocketAddr> addr_;
   bool connected_{false};
 };
 } // namespace metrics

--- a/exporters/geneva/src/unix_domain_socket_data_transport.cc
+++ b/exporters/geneva/src/unix_domain_socket_data_transport.cc
@@ -12,12 +12,12 @@ namespace metrics {
 UnixDomainSocketDataTransport::UnixDomainSocketDataTransport(
     const std::string &connection_string) 
 {      
-  addr_.reset(new geneva_metrics::SocketTools::SocketAddr(connection_string.c_str(), true));
+  addr_.reset(new ::opentelemetry::exporter::geneva::metrics::detail::SocketTools::SocketAddr(connection_string.c_str(), true));
 }
 
 bool UnixDomainSocketDataTransport::Connect() noexcept {
   if (!connected_) {
-    socket_ = geneva_metrics::SocketTools::Socket(socketparams_);
+    socket_ = ::opentelemetry::exporter::geneva::metrics::detail::SocketTools::Socket(socketparams_);
     connected_ = socket_.connect(*addr_);
     if (!connected_) {
       socket_.close();

--- a/exporters/geneva/src/unix_domain_socket_data_transport.cc
+++ b/exporters/geneva/src/unix_domain_socket_data_transport.cc
@@ -12,12 +12,12 @@ namespace metrics {
 UnixDomainSocketDataTransport::UnixDomainSocketDataTransport(
     const std::string &connection_string) 
 {      
-  addr_.reset(new SocketTools::SocketAddr(connection_string.c_str(), true));
+  addr_.reset(new geneva_metrics::SocketTools::SocketAddr(connection_string.c_str(), true));
 }
 
 bool UnixDomainSocketDataTransport::Connect() noexcept {
   if (!connected_) {
-    socket_ = SocketTools::Socket(socketparams_);
+    socket_ = geneva_metrics::SocketTools::Socket(socketparams_);
     connected_ = socket_.connect(*addr_);
     if (!connected_) {
       socket_.close();

--- a/exporters/geneva/src/unix_domain_socket_data_transport.cc
+++ b/exporters/geneva/src/unix_domain_socket_data_transport.cc
@@ -12,12 +12,12 @@ namespace metrics {
 UnixDomainSocketDataTransport::UnixDomainSocketDataTransport(
     const std::string &connection_string) 
 {      
-  addr_.reset(new ::opentelemetry::exporter::geneva::metrics::detail::SocketTools::SocketAddr(connection_string.c_str(), true));
+  addr_.reset(new detail::SocketTools::SocketAddr(connection_string.c_str(), true));
 }
 
 bool UnixDomainSocketDataTransport::Connect() noexcept {
   if (!connected_) {
-    socket_ = ::opentelemetry::exporter::geneva::metrics::detail::SocketTools::Socket(socketparams_);
+    socket_ = detail::SocketTools::Socket(socketparams_);
     connected_ = socket_.connect(*addr_);
     if (!connected_) {
       socket_.close();

--- a/exporters/geneva/test/common/socket_server.h
+++ b/exporters/geneva/test/common/socket_server.h
@@ -38,7 +38,8 @@
 #include "opentelemetry/exporters/geneva/metrics/macros.h"
 #include "opentelemetry/exporters/geneva/metrics/socket_tools.h"
 
-using namespace SocketTools;
+// Use geneva_metrics namespace for socket tools to avoid conflicts with fluentd
+using namespace geneva_metrics::SocketTools;
 
 namespace SOCKET_SERVER_NS {
 

--- a/exporters/geneva/test/common/socket_server.h
+++ b/exporters/geneva/test/common/socket_server.h
@@ -40,13 +40,12 @@
 
 namespace SOCKET_SERVER_NS {
 
-// Use geneva_metrics namespace for socket tools to avoid conflicts with fluentd
-using namespace geneva_metrics::SocketTools;
+namespace ST = geneva_metrics::SocketTools;
 
 /**
  * @brief Common Server for TCP, UDP and Unix Domain.
  */
-struct SocketServer : public Reactor::SocketCallback {
+struct SocketServer : public ST::Reactor::SocketCallback {
   struct Connection {
     enum State {
       Idle,       // No data transfer initiated
@@ -57,8 +56,8 @@ struct SocketServer : public Reactor::SocketCallback {
       Aborted     // Connection aborted
     };
 
-    Socket socket;     // Active client-server socket
-    SocketAddr client; // Client address
+    ST::Socket socket;     // Active client-server socket
+    ST::SocketAddr client; // Client address
 
     std::string request_buffer;  // Receive buffer for current event
     std::string response_buffer; // Send buffer for current event
@@ -67,11 +66,11 @@ struct SocketServer : public Reactor::SocketCallback {
     bool keepalive{true};  // Keep connection alive (reserved for future use)
   };
 
-  SocketAddr bind_address; // Server bind address
+  ST::SocketAddr bind_address; // Server bind address
   bool is_bound{false};
-  SocketParams server_socket_params; // Server socket params
-  Socket server_socket;              // Server listening socket
-  Reactor reactor;                   // Socket event handler
+  ST::SocketParams server_socket_params; // Server socket params
+  ST::Socket server_socket;              // Server listening socket
+  ST::Reactor reactor;                   // Socket event handler
 
   // Custom callback when server receives data
   std::function<void(Connection &conn)> onRequest;
@@ -81,12 +80,12 @@ struct SocketServer : public Reactor::SocketCallback {
 
   // Active client-server connections protected by recursive mutex
   std::recursive_mutex connections_mutex;
-  std::map<Socket, Connection> connections;
+  std::map<ST::Socket, Connection> connections;
 
   // Macro to safely obtain TEMPORARY string buffer pointer
 #define CLID(conn) conn.client.toString().c_str()
 
-  const SocketAddr &address() const { return bind_address; };
+  const ST::SocketAddr &address() const { return bind_address; };
 
   /**
    * @brief Route to start TCP, UDP or Unix Domain socket server.
@@ -94,9 +93,9 @@ struct SocketServer : public Reactor::SocketCallback {
    * @param sock Socket type.
    * @param numConnections Maximum number of connections.
    */
-  SocketServer(SocketAddr addr, SocketParams params, int numConnections = 10)
+  SocketServer(ST::SocketAddr addr, ST::SocketParams params, int numConnections = 10)
       : bind_address(addr), server_socket_params(params), reactor(*this) {
-    server_socket = Socket(server_socket_params);
+    server_socket = ST::Socket(server_socket_params);
 
     // Default lambda here implements an echo server
     onRequest = [this](Connection &conn) {
@@ -118,11 +117,11 @@ struct SocketServer : public Reactor::SocketCallback {
     server_socket.getsockname(bind_address);
     if (server_socket_params.type == SOCK_STREAM) {
       // In TCP and Unix Domain mode we listen and accept.
-      reactor.addSocket(server_socket, Reactor::Acceptable);
+      reactor.addSocket(server_socket, ST::Reactor::Acceptable);
       server_socket.listen(numConnections);
     } else {
       // In UDP mode we read in a loop, no need to accept.
-      reactor.addSocket(server_socket, Reactor::Readable);
+      reactor.addSocket(server_socket, ST::Reactor::Readable);
     }
 
     LOG_INFO("Server: Listening on %s://%s", server_socket_params.scheme(),
@@ -143,11 +142,11 @@ struct SocketServer : public Reactor::SocketCallback {
    * @brief Handle Reactor::State::Acceptable event.
    * @param socket Client socket.
    */
-  virtual void onSocketAcceptable(Socket socket) override {
+  virtual void onSocketAcceptable(ST::Socket socket) override {
     LOG_TRACE("Server: accepting socket fd=0x%llx", socket.m_sock);
 
-    Socket csocket;
-    SocketAddr caddr;
+    ST::Socket csocket;
+    ST::SocketAddr caddr;
     if (socket.accept(csocket, caddr)) {
 #ifdef HAVE_UNIX_DOMAIN
       // If server is Unix domain, then the client socket is also Unix domain
@@ -167,7 +166,7 @@ struct SocketServer : public Reactor::SocketCallback {
       conn.socket = csocket;
       conn.state = {Connection::Idle};
       conn.client = caddr;
-      reactor.addSocket(csocket, Reactor::Readable | Reactor::Closed);
+      reactor.addSocket(csocket, ST::Reactor::Readable | ST::Reactor::Closed);
       LOG_TRACE("Server: [%s] accepted", CLID(conn));
     }
   }
@@ -176,7 +175,7 @@ struct SocketServer : public Reactor::SocketCallback {
    * @brief Handle Reactor::State::Reasable event.
    * @param socket Client socket.
    */
-  virtual void onSocketReadable(Socket socket) override {
+  virtual void onSocketReadable(ST::Socket socket) override {
     LOG_TRACE("Server: reading socket fd=0x%x",
               static_cast<int>(socket.m_sock));
     int size = 0;
@@ -207,7 +206,7 @@ struct SocketServer : public Reactor::SocketCallback {
    * @brief Event triggered when server may write data back to client.
    * @param socket Client socket.
    */
-  virtual void onSocketWritable(Socket socket) override {
+  virtual void onSocketWritable(ST::Socket socket) override {
     LOG_TRACE("Server: writing socket fd=0x%llx", socket.m_sock);
     decltype(connections)::iterator it;
     {
@@ -227,7 +226,7 @@ struct SocketServer : public Reactor::SocketCallback {
    * @brief Handle event when socket is closed.
    * @param socket
    */
-  virtual void onSocketClosed(Socket socket) override {
+  virtual void onSocketClosed(ST::Socket socket) override {
     LOG_TRACE("Server: closing socket fd=0x%llx", socket.m_sock);
     LOCKGUARD(connections_mutex);
     auto it = connections.find(socket);
@@ -320,7 +319,7 @@ struct SocketServer : public Reactor::SocketCallback {
     }
 
     // Handle TCP and Unix Domain response
-    reactor.addSocket(conn.socket, Reactor::Writable);
+    reactor.addSocket(conn.socket, ST::Reactor::Writable);
     total_bytes_sent = conn.socket.writeall(conn.response_buffer.data(),
                                             conn.request_buffer.size());
     if (conn.response_buffer.size() != total_bytes_sent) {
@@ -372,7 +371,7 @@ struct SocketServer : public Reactor::SocketCallback {
 
   void CloseConnection(Connection &conn) {
     LOG_TRACE("Server: [%s] closing connection...", CLID(conn));
-    conn.socket.shutdown(Socket::ShutdownSend);
+    conn.socket.shutdown(ST::Socket::ShutdownSend);
     onConnectionClosed(conn);
   }
 
@@ -391,7 +390,7 @@ struct SocketServer : public Reactor::SocketCallback {
   void HandleConnection(Connection &conn) {
 
     if (conn.state.count(Connection::Responding)) {
-      reactor.addSocket(conn.socket, Reactor::Writable | Reactor::Closed);
+      reactor.addSocket(conn.socket, ST::Reactor::Writable | ST::Reactor::Closed);
       // Got data to send back
       LOG_TRACE("Server: [%s] responding...", CLID(conn));
       // If WriteResponseBuffer returns true, then more data to send.
@@ -400,7 +399,7 @@ struct SocketServer : public Reactor::SocketCallback {
       }
       // No more data to send. Stop responding.
       conn.state.erase(Connection::Responding);
-      reactor.addSocket(conn.socket, Reactor::Readable | Reactor::Closed);
+      reactor.addSocket(conn.socket, ST::Reactor::Readable | ST::Reactor::Closed);
     }
 
     if (conn.state.count(Connection::Closing)) {
@@ -412,7 +411,7 @@ struct SocketServer : public Reactor::SocketCallback {
     if (conn.keepalive) {
       LOG_TRACE("Server: [%s] idle (keep-alive)", CLID(conn));
       reactor.addSocket(conn.socket,
-                        Reactor::Readable | Reactor::Closed);
+                        ST::Reactor::Readable | ST::Reactor::Closed);
       conn.state.insert(Connection::Idle);
     }
   }

--- a/exporters/geneva/test/common/socket_server.h
+++ b/exporters/geneva/test/common/socket_server.h
@@ -40,7 +40,7 @@
 
 namespace SOCKET_SERVER_NS {
 
-namespace socket_tools = opentelemetry::exporter::geneva::metrics::detail::SocketTools;
+namespace socket_tools = opentelemetry::v1::exporter::geneva::metrics::detail::SocketTools;
 
 /**
  * @brief Common Server for TCP, UDP and Unix Domain.

--- a/exporters/geneva/test/common/socket_server.h
+++ b/exporters/geneva/test/common/socket_server.h
@@ -40,12 +40,12 @@
 
 namespace SOCKET_SERVER_NS {
 
-namespace ST = geneva_metrics::SocketTools;
+namespace socket_tools = opentelemetry::exporter::geneva::metrics::detail::SocketTools;
 
 /**
  * @brief Common Server for TCP, UDP and Unix Domain.
  */
-struct SocketServer : public ST::Reactor::SocketCallback {
+struct SocketServer : public socket_tools::Reactor::SocketCallback {
   struct Connection {
     enum State {
       Idle,       // No data transfer initiated
@@ -56,8 +56,8 @@ struct SocketServer : public ST::Reactor::SocketCallback {
       Aborted     // Connection aborted
     };
 
-    ST::Socket socket;     // Active client-server socket
-    ST::SocketAddr client; // Client address
+    socket_tools::Socket socket;     // Active client-server socket
+    socket_tools::SocketAddr client; // Client address
 
     std::string request_buffer;  // Receive buffer for current event
     std::string response_buffer; // Send buffer for current event
@@ -66,11 +66,11 @@ struct SocketServer : public ST::Reactor::SocketCallback {
     bool keepalive{true};  // Keep connection alive (reserved for future use)
   };
 
-  ST::SocketAddr bind_address; // Server bind address
+  socket_tools::SocketAddr bind_address; // Server bind address
   bool is_bound{false};
-  ST::SocketParams server_socket_params; // Server socket params
-  ST::Socket server_socket;              // Server listening socket
-  ST::Reactor reactor;                   // Socket event handler
+  socket_tools::SocketParams server_socket_params; // Server socket params
+  socket_tools::Socket server_socket;              // Server listening socket
+  socket_tools::Reactor reactor;                   // Socket event handler
 
   // Custom callback when server receives data
   std::function<void(Connection &conn)> onRequest;
@@ -80,12 +80,12 @@ struct SocketServer : public ST::Reactor::SocketCallback {
 
   // Active client-server connections protected by recursive mutex
   std::recursive_mutex connections_mutex;
-  std::map<ST::Socket, Connection> connections;
+  std::map<socket_tools::Socket, Connection> connections;
 
   // Macro to safely obtain TEMPORARY string buffer pointer
 #define CLID(conn) conn.client.toString().c_str()
 
-  const ST::SocketAddr &address() const { return bind_address; };
+  const socket_tools::SocketAddr &address() const { return bind_address; };
 
   /**
    * @brief Route to start TCP, UDP or Unix Domain socket server.
@@ -93,9 +93,9 @@ struct SocketServer : public ST::Reactor::SocketCallback {
    * @param sock Socket type.
    * @param numConnections Maximum number of connections.
    */
-  SocketServer(ST::SocketAddr addr, ST::SocketParams params, int numConnections = 10)
+  SocketServer(socket_tools::SocketAddr addr, socket_tools::SocketParams params, int numConnections = 10)
       : bind_address(addr), server_socket_params(params), reactor(*this) {
-    server_socket = ST::Socket(server_socket_params);
+    server_socket = socket_tools::Socket(server_socket_params);
 
     // Default lambda here implements an echo server
     onRequest = [this](Connection &conn) {
@@ -117,11 +117,11 @@ struct SocketServer : public ST::Reactor::SocketCallback {
     server_socket.getsockname(bind_address);
     if (server_socket_params.type == SOCK_STREAM) {
       // In TCP and Unix Domain mode we listen and accept.
-      reactor.addSocket(server_socket, ST::Reactor::Acceptable);
+      reactor.addSocket(server_socket, socket_tools::Reactor::Acceptable);
       server_socket.listen(numConnections);
     } else {
       // In UDP mode we read in a loop, no need to accept.
-      reactor.addSocket(server_socket, ST::Reactor::Readable);
+      reactor.addSocket(server_socket, socket_tools::Reactor::Readable);
     }
 
     LOG_INFO("Server: Listening on %s://%s", server_socket_params.scheme(),
@@ -142,11 +142,11 @@ struct SocketServer : public ST::Reactor::SocketCallback {
    * @brief Handle Reactor::State::Acceptable event.
    * @param socket Client socket.
    */
-  virtual void onSocketAcceptable(ST::Socket socket) override {
+  virtual void onSocketAcceptable(socket_tools::Socket socket) override {
     LOG_TRACE("Server: accepting socket fd=0x%llx", socket.m_sock);
 
-    ST::Socket csocket;
-    ST::SocketAddr caddr;
+    socket_tools::Socket csocket;
+    socket_tools::SocketAddr caddr;
     if (socket.accept(csocket, caddr)) {
 #ifdef HAVE_UNIX_DOMAIN
       // If server is Unix domain, then the client socket is also Unix domain
@@ -166,7 +166,7 @@ struct SocketServer : public ST::Reactor::SocketCallback {
       conn.socket = csocket;
       conn.state = {Connection::Idle};
       conn.client = caddr;
-      reactor.addSocket(csocket, ST::Reactor::Readable | ST::Reactor::Closed);
+      reactor.addSocket(csocket, socket_tools::Reactor::Readable | socket_tools::Reactor::Closed);
       LOG_TRACE("Server: [%s] accepted", CLID(conn));
     }
   }
@@ -175,7 +175,7 @@ struct SocketServer : public ST::Reactor::SocketCallback {
    * @brief Handle Reactor::State::Reasable event.
    * @param socket Client socket.
    */
-  virtual void onSocketReadable(ST::Socket socket) override {
+  virtual void onSocketReadable(socket_tools::Socket socket) override {
     LOG_TRACE("Server: reading socket fd=0x%x",
               static_cast<int>(socket.m_sock));
     int size = 0;
@@ -206,7 +206,7 @@ struct SocketServer : public ST::Reactor::SocketCallback {
    * @brief Event triggered when server may write data back to client.
    * @param socket Client socket.
    */
-  virtual void onSocketWritable(ST::Socket socket) override {
+  virtual void onSocketWritable(socket_tools::Socket socket) override {
     LOG_TRACE("Server: writing socket fd=0x%llx", socket.m_sock);
     decltype(connections)::iterator it;
     {
@@ -226,7 +226,7 @@ struct SocketServer : public ST::Reactor::SocketCallback {
    * @brief Handle event when socket is closed.
    * @param socket
    */
-  virtual void onSocketClosed(ST::Socket socket) override {
+  virtual void onSocketClosed(socket_tools::Socket socket) override {
     LOG_TRACE("Server: closing socket fd=0x%llx", socket.m_sock);
     LOCKGUARD(connections_mutex);
     auto it = connections.find(socket);
@@ -319,7 +319,7 @@ struct SocketServer : public ST::Reactor::SocketCallback {
     }
 
     // Handle TCP and Unix Domain response
-    reactor.addSocket(conn.socket, ST::Reactor::Writable);
+    reactor.addSocket(conn.socket, socket_tools::Reactor::Writable);
     total_bytes_sent = conn.socket.writeall(conn.response_buffer.data(),
                                             conn.request_buffer.size());
     if (conn.response_buffer.size() != total_bytes_sent) {
@@ -371,7 +371,7 @@ struct SocketServer : public ST::Reactor::SocketCallback {
 
   void CloseConnection(Connection &conn) {
     LOG_TRACE("Server: [%s] closing connection...", CLID(conn));
-    conn.socket.shutdown(ST::Socket::ShutdownSend);
+    conn.socket.shutdown(socket_tools::Socket::ShutdownSend);
     onConnectionClosed(conn);
   }
 
@@ -390,7 +390,7 @@ struct SocketServer : public ST::Reactor::SocketCallback {
   void HandleConnection(Connection &conn) {
 
     if (conn.state.count(Connection::Responding)) {
-      reactor.addSocket(conn.socket, ST::Reactor::Writable | ST::Reactor::Closed);
+      reactor.addSocket(conn.socket, socket_tools::Reactor::Writable | socket_tools::Reactor::Closed);
       // Got data to send back
       LOG_TRACE("Server: [%s] responding...", CLID(conn));
       // If WriteResponseBuffer returns true, then more data to send.
@@ -399,7 +399,7 @@ struct SocketServer : public ST::Reactor::SocketCallback {
       }
       // No more data to send. Stop responding.
       conn.state.erase(Connection::Responding);
-      reactor.addSocket(conn.socket, ST::Reactor::Readable | ST::Reactor::Closed);
+      reactor.addSocket(conn.socket, socket_tools::Reactor::Readable | socket_tools::Reactor::Closed);
     }
 
     if (conn.state.count(Connection::Closing)) {
@@ -411,7 +411,7 @@ struct SocketServer : public ST::Reactor::SocketCallback {
     if (conn.keepalive) {
       LOG_TRACE("Server: [%s] idle (keep-alive)", CLID(conn));
       reactor.addSocket(conn.socket,
-                        ST::Reactor::Readable | ST::Reactor::Closed);
+                        socket_tools::Reactor::Readable | socket_tools::Reactor::Closed);
       conn.state.insert(Connection::Idle);
     }
   }

--- a/exporters/geneva/test/common/socket_server.h
+++ b/exporters/geneva/test/common/socket_server.h
@@ -38,10 +38,10 @@
 #include "opentelemetry/exporters/geneva/metrics/macros.h"
 #include "opentelemetry/exporters/geneva/metrics/socket_tools.h"
 
+namespace SOCKET_SERVER_NS {
+
 // Use geneva_metrics namespace for socket tools to avoid conflicts with fluentd
 using namespace geneva_metrics::SocketTools;
-
-namespace SOCKET_SERVER_NS {
 
 /**
  * @brief Common Server for TCP, UDP and Unix Domain.
@@ -81,7 +81,7 @@ struct SocketServer : public Reactor::SocketCallback {
 
   // Active client-server connections protected by recursive mutex
   std::recursive_mutex connections_mutex;
-  std::map<SocketTools::Socket, Connection> connections;
+  std::map<Socket, Connection> connections;
 
   // Macro to safely obtain TEMPORARY string buffer pointer
 #define CLID(conn) conn.client.toString().c_str()
@@ -320,7 +320,7 @@ struct SocketServer : public Reactor::SocketCallback {
     }
 
     // Handle TCP and Unix Domain response
-    reactor.addSocket(conn.socket, SocketTools::Reactor::Writable);
+    reactor.addSocket(conn.socket, Reactor::Writable);
     total_bytes_sent = conn.socket.writeall(conn.response_buffer.data(),
                                             conn.request_buffer.size());
     if (conn.response_buffer.size() != total_bytes_sent) {
@@ -372,7 +372,7 @@ struct SocketServer : public Reactor::SocketCallback {
 
   void CloseConnection(Connection &conn) {
     LOG_TRACE("Server: [%s] closing connection...", CLID(conn));
-    conn.socket.shutdown(SocketTools::Socket::ShutdownSend);
+    conn.socket.shutdown(Socket::ShutdownSend);
     onConnectionClosed(conn);
   }
 
@@ -412,7 +412,7 @@ struct SocketServer : public Reactor::SocketCallback {
     if (conn.keepalive) {
       LOG_TRACE("Server: [%s] idle (keep-alive)", CLID(conn));
       reactor.addSocket(conn.socket,
-                        SocketTools::Reactor::Readable | Reactor::Closed);
+                        Reactor::Readable | Reactor::Closed);
       conn.state.insert(Connection::Idle);
     }
   }

--- a/exporters/geneva/test/metrics_exporter_test.cc
+++ b/exporters/geneva/test/metrics_exporter_test.cc
@@ -314,8 +314,8 @@ TEST_P(GenericMetricsExporterTextFixture, BasicTests)
   bool isRunning              = true;
 
   // Start test server
-  geneva_metrics::SocketTools::SocketAddr destination(kUnixDomainPath.data(), true);
-  geneva_metrics::SocketTools::SocketParams params{AF_UNIX, SOCK_STREAM, 0};
+  opentelemetry::v1::exporter::geneva::metrics::detail::SocketTools::SocketAddr destination(kUnixDomainPath.data(), true);
+  opentelemetry::v1::exporter::geneva::metrics::detail::SocketTools::SocketParams params{AF_UNIX, SOCK_STREAM, 0};
   SocketServer socketServer(destination, params);
   TestServer testServer(socketServer);
   testServer.Start();

--- a/exporters/geneva/test/metrics_exporter_test.cc
+++ b/exporters/geneva/test/metrics_exporter_test.cc
@@ -314,8 +314,8 @@ TEST_P(GenericMetricsExporterTextFixture, BasicTests)
   bool isRunning              = true;
 
   // Start test server
-  SocketAddr destination(kUnixDomainPath.data(), true);
-  SocketParams params{AF_UNIX, SOCK_STREAM, 0};
+  geneva_metrics::SocketTools::SocketAddr destination(kUnixDomainPath.data(), true);
+  geneva_metrics::SocketTools::SocketParams params{AF_UNIX, SOCK_STREAM, 0};
   SocketServer socketServer(destination, params);
   TestServer testServer(socketServer);
   testServer.Start();


### PR DESCRIPTION
Problem
When including both Geneva exporter headers for logs and metrics in the same translation unit on Linux, the build fails with an ODR (One Definition Rule) violation:
#include "opentelemetry/exporters/geneva/geneva_logger_exporter.h"
#include "opentelemetry/exporters/geneva/metrics/exporter.h"

error: redefinition of 'struct net::Thread'
note: previous definition of 'struct net::Thread'Root Cause: 
Both fluentd/common/socket_tools.h (used by Geneva logger) and geneva/metrics/socket_tools.h (used by Geneva metrics) define identical types (net::Thread, SocketTools::Socket, etc.) in the same global namespaces, causing ODR violations when both headers are included

Solution
Wrapped all socket tools definitions in geneva/metrics/socket_tools.h in a unique geneva_metrics namespace to avoid conflicts:

net::Thread → geneva_metrics::net::Thread
SocketTools::Socket → geneva_metrics::SocketTools::Socket
Added using namespace geneva_metrics; in dependent headers for transparent usage
