### PR TITLE
[Geneva] Fix connection string sample in comment

### DIFF
--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/exporter_options.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/exporter_options.h
@@ -17,7 +17,7 @@ struct ExporterOptions {
   /*
   Format -
     Windows:
-        Account={MetricAccount};NameSpace={MetricNamespace}
+        Account={MetricAccount};Namespace={MetricNamespace}
     Linux:
         Endpoint=unix://{UDS Path};Account={MetricAccount};Namespace={MetricNamespace}
   */


### PR DESCRIPTION
The sample contains a typo that renders the connection string invalid, fix it to avoid confusion.