### PR TITLE
[geneva/metrics] prevent buffer overflow in attribute serialization

### DIFF
--- a/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/exporter.h
+++ b/exporters/geneva/include/opentelemetry/exporters/geneva/metrics/exporter.h
@@ -87,20 +87,36 @@ private:
       const std::string &, const sdk::metrics::PointAttributes &);
 };
 
+// Serializes an integer into buffer at index, advancing index by sizeof(T).
+// Returns false (and writes nothing) if the value would not fit within
+// kBufferSize, so callers can abort instead of overflowing buffer_.
 template <class T>
-static void SerializeInt(char *buffer, size_t &index, T value) {
-  *(reinterpret_cast<T *>(buffer + index)) = value;
+static bool SerializeInt(char *buffer, size_t &index, T value) {
+  if (index + sizeof(T) > kBufferSize) {
+    return false;
+  }
+  // buffer is a char array and (buffer + index) may be unaligned for T; use
+  // memcpy for an alignment-safe store (avoids UB from misaligned writes).
+  memcpy(buffer + index, &value, sizeof(T));
   index += sizeof(T);
+  return true;
 }
 
-static void SerializeString(char *buffer, size_t &index,
+// Serializes a length-prefixed string into buffer at index. Returns false
+// (and writes nothing) if the 2-byte length prefix plus the string would not
+// fit within kBufferSize, preventing buffer overflow.
+static bool SerializeString(char *buffer, size_t &index,
                             const std::string &str) {
   auto size = str.size();
+  if (index + sizeof(uint16_t) + size > kBufferSize) {
+    return false;
+  }
   SerializeInt<uint16_t>(buffer, index, static_cast<uint16_t>(size));
   if (size > 0) {
     memcpy(buffer + index, str.c_str(), size);
   }
   index += size;
+  return true;
 }
 
 static std::string AttributeValueToString(

--- a/exporters/geneva/src/exporter.cc
+++ b/exporters/geneva/src/exporter.cc
@@ -105,8 +105,10 @@ opentelemetry::sdk::common::ExportResult Exporter::Export(
               sdk::metrics::AggregationType::kSum, event_type, new_value,
               metric_data.end_ts, metric_data.instrument_descriptor.name_,
               point_data_with_attributes.attributes);
-          data_transport_->Send(event_type, buffer_,
-                                body_length + kBinaryHeaderSize);
+          if (body_length > 0) {
+            data_transport_->Send(event_type, buffer_,
+                                  body_length + kBinaryHeaderSize);
+          }
 
         } else if (nostd::holds_alternative<sdk::metrics::LastValuePointData>(
                        point_data_with_attributes.point_data)) {
@@ -126,8 +128,10 @@ opentelemetry::sdk::common::ExportResult Exporter::Export(
               sdk::metrics::AggregationType::kLastValue, event_type, new_value,
               metric_data.end_ts, metric_data.instrument_descriptor.name_,
               point_data_with_attributes.attributes);
-          data_transport_->Send(event_type, buffer_,
-                                body_length + kBinaryHeaderSize);
+          if (body_length > 0) {
+            data_transport_->Send(event_type, buffer_,
+                                  body_length + kBinaryHeaderSize);
+          }
         } else if (nostd::holds_alternative<sdk::metrics::HistogramPointData>(
                        point_data_with_attributes.point_data)) {
           auto value = nostd::get<sdk::metrics::HistogramPointData>(
@@ -155,8 +159,10 @@ opentelemetry::sdk::common::ExportResult Exporter::Export(
                   .counts_,
               metric_data.end_ts, metric_data.instrument_descriptor.name_,
               point_data_with_attributes.attributes);
-          data_transport_->Send(event_type, buffer_,
-                                body_length + kBinaryHeaderSize);
+          if (body_length > 0) {
+            data_transport_->Send(event_type, buffer_,
+                                  body_length + kBinaryHeaderSize);
+          }
         }
       }
     }
@@ -204,11 +210,15 @@ size_t Exporter::SerializeNonHistogramMetrics(
   }
 
   // account name
-  SerializeString(buffer_, bufferIndex, account_name);
   // namespace
-  SerializeString(buffer_, bufferIndex, account_namespace);
   // metric name
-  SerializeString(buffer_, bufferIndex, metric_name);
+  if (!SerializeString(buffer_, bufferIndex, account_name) ||
+      !SerializeString(buffer_, bufferIndex, account_namespace) ||
+      !SerializeString(buffer_, bufferIndex, metric_name)) {
+    LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+             metric_name.c_str());
+    return 0;
+  }
 
   uint16_t attributes_size = 0;
 
@@ -220,7 +230,11 @@ size_t Exporter::SerializeNonHistogramMetrics(
       continue;
     }
     attributes_size++;
-    SerializeString(buffer_, bufferIndex, kv.first);
+    if (!SerializeString(buffer_, bufferIndex, kv.first)) {
+      LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+               metric_name.c_str());
+      return 0;
+    }
   }
 
   for (const auto &kv : attributes) {
@@ -236,7 +250,11 @@ size_t Exporter::SerializeNonHistogramMetrics(
       continue;
     }
     attributes_size++;
-    SerializeString(buffer_, bufferIndex, kv.first);
+    if (!SerializeString(buffer_, bufferIndex, kv.first)) {
+      LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+               metric_name.c_str());
+      return 0;
+    }
   }
 
   // serialize prepopulated values
@@ -245,7 +263,11 @@ size_t Exporter::SerializeNonHistogramMetrics(
       // warning is already logged earlier, no logging again
       continue;
     }
-    SerializeString(buffer_, bufferIndex, kv.second);
+    if (!SerializeString(buffer_, bufferIndex, kv.second)) {
+      LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+               metric_name.c_str());
+      return 0;
+    }
   }
 
   for (const auto &kv : attributes) {
@@ -261,7 +283,16 @@ size_t Exporter::SerializeNonHistogramMetrics(
       continue;
     }
     auto attr_value = AttributeValueToString(kv.second);
-    SerializeString(buffer_, bufferIndex, attr_value);
+    if (attr_value.size() > kMaxDimensionValueSize) {
+      LOG_WARN("Dimension value limit overflow: key=%s Limit: %zu",
+               kv.first.c_str(), kMaxDimensionValueSize);
+      attr_value.resize(kMaxDimensionValueSize);
+    }
+    if (!SerializeString(buffer_, bufferIndex, attr_value)) {
+      LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+               metric_name.c_str());
+      return 0;
+    }
   }
   // length zero for auto-pilot
   SerializeInt<uint16_t>(buffer_, bufferIndex, 0);
@@ -342,11 +373,15 @@ size_t Exporter::SerializeHistogramMetrics(
   }
 
   // account name
-  SerializeString(buffer_, bufferIndex, account_name);
   // namespace
-  SerializeString(buffer_, bufferIndex, account_namespace);
   // metric name
-  SerializeString(buffer_, bufferIndex, metric_name);
+  if (!SerializeString(buffer_, bufferIndex, account_name) ||
+      !SerializeString(buffer_, bufferIndex, account_namespace) ||
+      !SerializeString(buffer_, bufferIndex, metric_name)) {
+    LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+             metric_name.c_str());
+    return 0;
+  }
 
   uint16_t attributes_size = 0;
 
@@ -358,7 +393,11 @@ size_t Exporter::SerializeHistogramMetrics(
       continue;
     }
     attributes_size++;
-    SerializeString(buffer_, bufferIndex, kv.first);
+    if (!SerializeString(buffer_, bufferIndex, kv.first)) {
+      LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+               metric_name.c_str());
+      return 0;
+    }
   }
 
   // dimentions - name
@@ -375,7 +414,11 @@ size_t Exporter::SerializeHistogramMetrics(
       continue;
     }
     attributes_size++;
-    SerializeString(buffer_, bufferIndex, kv.first);
+    if (!SerializeString(buffer_, bufferIndex, kv.first)) {
+      LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+               metric_name.c_str());
+      return 0;
+    }
   }
 
 
@@ -385,7 +428,11 @@ size_t Exporter::SerializeHistogramMetrics(
       // warning is already logged earlier, no logging again
       continue;
     }
-    SerializeString(buffer_, bufferIndex, kv.second);
+    if (!SerializeString(buffer_, bufferIndex, kv.second)) {
+      LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+               metric_name.c_str());
+      return 0;
+    }
   }
 
   // dimentions - value
@@ -401,7 +448,16 @@ size_t Exporter::SerializeHistogramMetrics(
       continue;
     }
     auto attr_value = AttributeValueToString(kv.second);
-    SerializeString(buffer_, bufferIndex, attr_value);
+    if (attr_value.size() > kMaxDimensionValueSize) {
+      LOG_WARN("Dimension value limit overflow: key=%s Limit: %zu",
+               kv.first.c_str(), kMaxDimensionValueSize);
+      attr_value.resize(kMaxDimensionValueSize);
+    }
+    if (!SerializeString(buffer_, bufferIndex, attr_value)) {
+      LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+               metric_name.c_str());
+      return 0;
+    }
   }
 
   // two bytes padding for auto-pilot

--- a/exporters/geneva/src/exporter.cc
+++ b/exporters/geneva/src/exporter.cc
@@ -295,7 +295,11 @@ size_t Exporter::SerializeNonHistogramMetrics(
     }
   }
   // length zero for auto-pilot
-  SerializeInt<uint16_t>(buffer_, bufferIndex, 0);
+  if (!SerializeInt<uint16_t>(buffer_, bufferIndex, 0)) {
+    LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+             metric_name.c_str());
+    return 0;
+  }
 
   // get final size of payload to be added in front of buffer
   uint16_t body_length = bufferIndex - kBinaryHeaderSize;
@@ -332,9 +336,13 @@ size_t Exporter::SerializeNonHistogramMetrics(
     SerializeInt<uint64_t>(buffer_, bufferIndex,
                            static_cast<uint64_t>(nostd::get<int64_t>(value)));
   } else if (event_type == MetricsEventType::DoubleMetric) {
-    SerializeInt<uint64_t>(
-        buffer_, bufferIndex,
-        *(reinterpret_cast<const uint64_t *>(&(nostd::get<double>(value)))));
+    // Reinterpret the double's bit pattern as uint64_t via memcpy to avoid
+    // strict-aliasing UB (a reinterpret_cast read would alias double as
+    // uint64_t).
+    double double_value = nostd::get<double>(value);
+    uint64_t double_bits;
+    memcpy(&double_bits, &double_value, sizeof(double_bits));
+    SerializeInt<uint64_t>(buffer_, bufferIndex, double_bits);
   } else {
     // Won't reach here.
   }
@@ -460,20 +468,24 @@ size_t Exporter::SerializeHistogramMetrics(
     }
   }
 
-  // two bytes padding for auto-pilot
-  SerializeInt<uint16_t>(buffer_, bufferIndex, 0);
-
-  // version - set as 0
-  SerializeInt<uint8_t>(buffer_, bufferIndex, 0);
-
-  // Meta-data
+  // two bytes padding for auto-pilot, version, and distribution_type.
   // Value-count pairs is associated with the constant value of 2 in the
   // distribution_type enum.
-  SerializeInt<uint8_t>(buffer_, bufferIndex, 2);
+  if (!SerializeInt<uint16_t>(buffer_, bufferIndex, 0) || // padding
+      !SerializeInt<uint8_t>(buffer_, bufferIndex, 0) ||  // version
+      !SerializeInt<uint8_t>(buffer_, bufferIndex, 2)) {  // distribution_type
+    LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+             metric_name.c_str());
+    return 0;
+  }
 
   // Keep a position to record how many buckets are added
   auto itemsWrittenIndex = bufferIndex;
-  SerializeInt<uint16_t>(buffer_, bufferIndex, 0);
+  if (!SerializeInt<uint16_t>(buffer_, bufferIndex, 0)) {
+    LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+             metric_name.c_str());
+    return 0;
+  }
 
   // bucket values
   size_t index = 0;
@@ -481,11 +493,15 @@ size_t Exporter::SerializeHistogramMetrics(
   if (event_type ==
       MetricsEventType::ExternallyAggregatedUlongDistributionMetric) {
     for (auto boundary : boundaries) {
-      if (counts[index] > 0) {
-        SerializeInt<uint64_t>(buffer_, bufferIndex,
-                               static_cast<uint64_t>(boundary));
-        SerializeInt<uint32_t>(buffer_, bufferIndex,
-                               (uint32_t)(counts[index]));
+      if (index < counts.size() && counts[index] > 0) {
+        if (!SerializeInt<uint64_t>(buffer_, bufferIndex,
+                                    static_cast<uint64_t>(boundary)) ||
+            !SerializeInt<uint32_t>(buffer_, bufferIndex,
+                                    (uint32_t)(counts[index]))) {
+          LOG_WARN("Metric payload exceeds buffer size, dropping metric: %s",
+                   metric_name.c_str());
+          return 0;
+        }
         bucket_count++;
       }
       index++;

--- a/exporters/geneva/test/metrics_exporter_test.cc
+++ b/exporters/geneva/test/metrics_exporter_test.cc
@@ -473,4 +473,75 @@ TEST(GenevaExporterTest, SingleOversizedValueIsClampedNotOverflowed) {
             opentelemetry::sdk::common::ExportResult::kSuccess);
 }
 
+static inline opentelemetry::sdk::metrics::ResourceMetrics
+MakeHistogramLongMetrics(const std::vector<double> &boundaries,
+                         const std::vector<uint64_t> &counts) {
+  opentelemetry::sdk::metrics::HistogramPointData histogram_point_data{};
+  histogram_point_data.boundaries_ = boundaries;
+  histogram_point_data.counts_ = counts;
+  histogram_point_data.count_ = counts.size();
+  histogram_point_data.sum_ = static_cast<int64_t>(0);
+  histogram_point_data.min_ = static_cast<int64_t>(0);
+  histogram_point_data.max_ = static_cast<int64_t>(boundaries.size());
+
+  static opentelemetry::sdk::resource::Resource resource =
+      opentelemetry::sdk::resource::Resource::Create(
+          opentelemetry::sdk::resource::ResourceAttributes{});
+  static auto scope =
+      opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create(
+          "overflow_test_lib", "1.0.0");
+
+  opentelemetry::sdk::metrics::MetricData metric_data{
+      opentelemetry::sdk::metrics::InstrumentDescriptor{
+          "overflow_histogram", "desc", "unit",
+          opentelemetry::sdk::metrics::InstrumentType::kHistogram,
+          opentelemetry::sdk::metrics::InstrumentValueType::kLong},
+      opentelemetry::sdk::metrics::AggregationTemporality::kDelta,
+      opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
+      opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
+      std::vector<opentelemetry::sdk::metrics::PointDataAttributes>{
+          {opentelemetry::sdk::metrics::PointAttributes{}, histogram_point_data}}};
+
+  opentelemetry::sdk::metrics::ResourceMetrics data;
+  data.resource_ = &resource;
+  data.scope_metric_data_ =
+      std::vector<opentelemetry::sdk::metrics::ScopeMetrics>{
+          {scope.get(),
+           std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
+  return data;
+}
+
+TEST(GenevaExporterTest, HistogramManyBucketsDoNotOverflowBuffer) {
+  ExporterOptions options{
+      "Endpoint=unix:///tmp/geneva_hist_test;Account=test;Namespace=test"};
+  Exporter exporter(options);
+
+  const size_t kNumBuckets = 6000;
+  std::vector<double> boundaries(kNumBuckets);
+  for (size_t i = 0; i < kNumBuckets; i++) {
+    boundaries[i] = static_cast<double>(i);
+  }
+  // All buckets non-empty so every one is serialized.
+  std::vector<uint64_t> counts(kNumBuckets + 1, 1);
+
+  EXPECT_EQ(exporter.Export(MakeHistogramLongMetrics(boundaries, counts)),
+            opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
+TEST(GenevaExporterTest, HistogramMismatchedCountsDoesNotReadOutOfBounds) {
+  ExporterOptions options{
+      "Endpoint=unix:///tmp/geneva_hist_mismatch_test;Account=test;Namespace=test"};
+  Exporter exporter(options);
+
+  std::vector<double> boundaries(8);
+  for (size_t i = 0; i < boundaries.size(); i++) {
+    boundaries[i] = static_cast<double>(i);
+  }
+  // Deliberately shorter than boundaries (SDK normally guarantees size + 1).
+  std::vector<uint64_t> counts(2, 1);
+
+  EXPECT_EQ(exporter.Export(MakeHistogramLongMetrics(boundaries, counts)),
+            opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
 #endif

--- a/exporters/geneva/test/metrics_exporter_test.cc
+++ b/exporters/geneva/test/metrics_exporter_test.cc
@@ -399,4 +399,78 @@ TEST(GenevaExporterTest, GetAggregationTemporalityTest) {
             AggregationTemporality::kDelta);
 }
 
+// Builds a ResourceMetrics carrying a single Sum (long) point whose attributes
+// are supplied by the caller. Used by the buffer-overflow regression tests.
+static inline opentelemetry::sdk::metrics::ResourceMetrics
+MakeSumLongMetricsWithAttributes(
+    const opentelemetry::sdk::metrics::PointAttributes &attributes) {
+  opentelemetry::sdk::metrics::SumPointData sum_point_data{};
+  sum_point_data.value_ = static_cast<int64_t>(42);
+  sum_point_data.is_monotonic_ = true;
+
+  static opentelemetry::sdk::resource::Resource resource =
+      opentelemetry::sdk::resource::Resource::Create(
+          opentelemetry::sdk::resource::ResourceAttributes{});
+  static auto scope =
+      opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create(
+          "overflow_test_lib", "1.0.0");
+
+  opentelemetry::sdk::metrics::MetricData metric_data{
+      opentelemetry::sdk::metrics::InstrumentDescriptor{
+          "overflow_metric", "desc", "unit",
+          opentelemetry::sdk::metrics::InstrumentType::kCounter,
+          opentelemetry::sdk::metrics::InstrumentValueType::kLong},
+      opentelemetry::sdk::metrics::AggregationTemporality::kDelta,
+      opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
+      opentelemetry::common::SystemTimestamp{std::chrono::system_clock::now()},
+      std::vector<opentelemetry::sdk::metrics::PointDataAttributes>{
+          {attributes, sum_point_data}}};
+
+  opentelemetry::sdk::metrics::ResourceMetrics data;
+  data.resource_ = &resource;
+  data.scope_metric_data_ =
+      std::vector<opentelemetry::sdk::metrics::ScopeMetrics>{
+          {scope.get(),
+           std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
+  return data;
+}
+
+// Regression test: attribute values whose total serialized size exceeds
+// kBufferSize (65360) must NOT overflow buffer_. Before the fix this PoC
+// (90 x 1024-byte values ~= 92 KB) triggered an AddressSanitizer
+// global-buffer-overflow inside SerializeString. The fix drops the oversized
+// metric instead of overflowing; Export must still complete cleanly.
+TEST(GenevaExporterTest, OversizedAttributesDoNotOverflowBuffer) {
+  ExporterOptions options{
+      "Endpoint=unix:///tmp/geneva_overflow_test;Account=test;Namespace=test"};
+  Exporter exporter(options);
+
+  PointAttributes attributes;
+  for (int i = 0; i < 90; i++) {
+    attributes.emplace("attr_" + std::to_string(i),
+                       std::string(kMaxDimensionValueSize, 'A'));
+  }
+
+  // Must not overflow buffer_ (validated under ASan/UBSan) and must return
+  // success rather than crashing.
+  EXPECT_EQ(exporter.Export(MakeSumLongMetricsWithAttributes(attributes)),
+            opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
+// Regression test: a single attribute value larger than kMaxDimensionValueSize
+// (but small enough that the metric still fits) is clamped, not rejected, and
+// serialization stays within bounds.
+TEST(GenevaExporterTest, SingleOversizedValueIsClampedNotOverflowed) {
+  ExporterOptions options{
+      "Endpoint=unix:///tmp/geneva_clamp_test;Account=test;Namespace=test"};
+  Exporter exporter(options);
+
+  PointAttributes attributes;
+  attributes.emplace("big_value",
+                     std::string(kMaxDimensionValueSize * 4, 'B'));
+
+  EXPECT_EQ(exporter.Export(MakeSumLongMetricsWithAttributes(attributes)),
+            opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
 #endif


### PR DESCRIPTION
`SerializeString`/`SerializeInt` wrote into the fixed `buffer_[kBufferSize]` (65360 bytes) with no bounds check, so attributes whose total serialized size exceeded the buffer overflowed it). The declared `kMaxDimensionValueSize` (1024) cap was never enforced on values, and the `uint16_t` length prefix was stored via an unaligned `reinterpret_cast`.