### PR TITLE
[spdlog] fix type conversion error

### DIFF
--- a/instrumentation/spdlog/src/sink.cc
+++ b/instrumentation/spdlog/src/sink.cc
@@ -37,7 +37,7 @@ void OpenTelemetrySink<Mutex>::sink_it_(const spdlog::details::log_msg &msg)
       log_record->SetAttribute(kCodeFilePath, msg.source.filename);
       log_record->SetAttribute(kCodeLineNumber, msg.source.line);
     }
-    log_record->SetAttribute(kThreadId, msg.thread_id);
+    log_record->SetAttribute(kThreadId, static_cast<uint32_t>(msg.thread_id));
     logger->EmitLogRecord(std::move(log_record));
   }
 }

--- a/instrumentation/spdlog/src/sink.cc
+++ b/instrumentation/spdlog/src/sink.cc
@@ -37,7 +37,7 @@ void OpenTelemetrySink<Mutex>::sink_it_(const spdlog::details::log_msg &msg)
       log_record->SetAttribute(kCodeFilePath, msg.source.filename);
       log_record->SetAttribute(kCodeLineNumber, msg.source.line);
     }
-    log_record->SetAttribute(kThreadId, static_cast<uint32_t>(msg.thread_id));
+    log_record->SetAttribute(kThreadId, static_cast<uint64_t>(msg.thread_id));
     logger->EmitLogRecord(std::move(log_record));
   }
 }


### PR DESCRIPTION
Hi there, I was planning on using the spdlog sink, but I noticed it wasn't compiling on my machine. It seems like on some systems `opentelemetry::common::AttributeValue` cannot accept `size_t`. 

Looking at what clang is deducing the types as it seems the issue is that uint32_t evaluates to `unsigned int`, uint64_t to `unsigned long long`, but size_t to `unsigned long`. 

Since `size_t` is only _guaranteed_ to hold at least 32 bits, I'm proposing we use a static cast to `uint32_t`. Alternatives would be casting to `uint64_t` (which is not officially supported in the standard but would never lose information) or splitting it into a `nostd::span` if the platform has a 64-bit size_t implementation.

For context I am compiling on an M2 mac with macOs 15.7.4 using LLVM clang. 