### PR TITLE
chore: Add Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,32 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:best-practices",
+    "helpers:pinGitHubActionDigestsToSemver",
+    ":separateMultipleMajorReleases",
+  ],
+  packageRules: [
+    {
+      dependencyDashboardApproval: true,
+      matchManagers: ["!github-actions"],
+    },
+    {
+      groupName: "all patching",
+      matchUpdateTypes: ["patch", "digest"],
+      matchManagers: ["github-actions"],
+      schedule: ["before 6am every weekday"],
+    },
+    {
+      groupName: "infra updates",
+      matchCategories: ["ci"],
+      matchUpdateTypes: ["minor"],
+      matchManagers: ["github-actions"],
+      schedule: ["before 8am Monday"],
+    },
+    {
+      matchUpdateTypes: ["minor"],
+      matchManagers: ["github-actions"],
+      schedule: ["before 8am Monday"],
+    },
+  ],
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,7 +24,7 @@
       schedule: ["before 8am Monday"],
     },
     {
-      matchUpdateTypes: ["minor"],
+      matchUpdateTypes: ["major"],
       matchManagers: ["github-actions"],
       schedule: ["before 8am Monday"],
     },


### PR DESCRIPTION
Added package rules for dependency management in Renovate configuration.

Note to help adoption current config will only raise pr’s automatically for github actions, the rest will be visible via dashboard.

C++ is 1 of the 2 language sigs which haven’t switched.

Renovate enables pinning of gh actions to sha, better package registry support & sourcing of packages.