### PR TITLE
Define apt packages in a file

### DIFF
--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -41,20 +41,10 @@ jobs:
           path: "opentelemetry-cpp"
           submodules: "recursive"
       - name: setup dependencies
+        working-directory: opentelemetry-cpp-contrib/instrumentation/boost_log
         run: |
           sudo apt update -y
-          sudo apt install -y --no-install-recommends --no-install-suggests \
-            build-essential \
-            cmake \
-            ninja-build \
-            libssl-dev \
-            libcurl4-openssl-dev \
-            libprotobuf-dev \
-            protobuf-compiler \
-            libgmock-dev \
-            libgtest-dev \
-            libbenchmark-dev \
-            libboost-log-dev
+          xargs -a apt-packages.txt sudo apt install -y --no-install-recommends --no-install-suggests
 
       # This is needed because libgmock-dev libgtest-dev installs 1.11,
       # and 1.11 breaks the build.

--- a/.github/workflows/fluentd.yml
+++ b/.github/workflows/fluentd.yml
@@ -36,17 +36,10 @@ jobs:
           path: "opentelemetry-cpp"
           submodules: "recursive"
       - name: setup dependencies
+        working-directory: opentelemetry-cpp-contrib/exporters/fluentd
         run: |
           sudo apt update -y
-          sudo apt install -y --no-install-recommends --no-install-suggests \
-            build-essential \
-            cmake \
-            ninja-build \
-            libssl-dev \
-            libcurl4-openssl-dev \
-            libgmock-dev \
-            libgtest-dev \
-            libbenchmark-dev
+          xargs -a apt-packages.txt sudo apt install -y --no-install-recommends --no-install-suggests
 
       - name: build and test
         run: |

--- a/.github/workflows/geneva_metrics.yml
+++ b/.github/workflows/geneva_metrics.yml
@@ -30,10 +30,10 @@ jobs:
           path: "otel_cpp"
           submodules: "recursive"
       - name: setup
+        working-directory: otel_cpp_contrib/exporters/geneva
         run: |
           sudo apt update -y 
-          sudo apt install -y --no-install-recommends --no-install-suggests build-essential\
-            ca-certificates wget git valgrind lcov
+          xargs -a apt-packages.txt sudo apt install -y --no-install-recommends --no-install-suggests
       - name: run tests
         run: |
           pushd "$GITHUB_WORKSPACE/otel_cpp"

--- a/.github/workflows/glog.yml
+++ b/.github/workflows/glog.yml
@@ -45,19 +45,10 @@ jobs:
           path: "opentelemetry-cpp"
           submodules: "recursive"
       - name: setup dependencies
+        working-directory: opentelemetry-cpp-contrib/instrumentation/glog
         run: |
           sudo apt update -y
-          sudo apt install -y --no-install-recommends --no-install-suggests \
-            build-essential \
-            cmake \
-            ninja-build \
-            libssl-dev \
-            libcurl4-openssl-dev \
-            libprotobuf-dev \
-            protobuf-compiler \
-            libgmock-dev \
-            libgtest-dev \
-            libbenchmark-dev
+          xargs -a apt-packages.txt sudo apt install -y --no-install-recommends --no-install-suggests
 
       # This is needed because libgmock-dev libgtest-dev installs 1.11,
       # and 1.11 breaks the build.

--- a/.github/workflows/log4cxx.yml
+++ b/.github/workflows/log4cxx.yml
@@ -45,20 +45,10 @@ jobs:
           path: "opentelemetry-cpp"
           submodules: "recursive"
       - name: setup dependencies
+        working-directory: opentelemetry-cpp-contrib/instrumentation/log4cxx
         run: |
           sudo apt update -y
-          sudo apt install -y --no-install-recommends --no-install-suggests \
-            build-essential \
-            cmake \
-            ninja-build \
-            libssl-dev \
-            libcurl4-openssl-dev \
-            libprotobuf-dev \
-            protobuf-compiler \
-            libgmock-dev \
-            libgtest-dev \
-            libbenchmark-dev \
-            liblog4cxx-dev
+          xargs -a apt-packages.txt sudo apt install -y --no-install-recommends --no-install-suggests
 
       # This is needed because libgmock-dev libgtest-dev installs 1.11,
       # and v1.12 is required

--- a/.github/workflows/spdlog.yml
+++ b/.github/workflows/spdlog.yml
@@ -39,20 +39,10 @@ jobs:
           path: "opentelemetry-cpp"
           submodules: "recursive"
       - name: setup dependencies
+        working-directory: opentelemetry-cpp-contrib/instrumentation/spdlog
         run: |
           sudo apt update -y
-          sudo apt install -y --no-install-recommends --no-install-suggests \
-            build-essential \
-            cmake \
-            ninja-build \
-            libssl-dev \
-            libcurl4-openssl-dev \
-            libprotobuf-dev \
-            protobuf-compiler \
-            libgmock-dev \
-            libgtest-dev \
-            libbenchmark-dev \
-            libspdlog-dev
+          xargs -a apt-packages.txt sudo apt install -y --no-install-recommends --no-install-suggests
 
       # This is needed because libgmock-dev libgtest-dev installs 1.11,
       # and 1.11 breaks the build.

--- a/.github/workflows/user_events.yml
+++ b/.github/workflows/user_events.yml
@@ -34,19 +34,10 @@ jobs:
           path: "opentelemetry-cpp"
           submodules: "recursive"
       - name: setup dependencies
+        working-directory: opentelemetry-cpp-contrib/exporters/user_events
         run: |
           sudo apt update -y
-          sudo apt install -y --no-install-recommends --no-install-suggests \
-            build-essential \
-            cmake \
-            ninja-build \
-            libssl-dev \
-            libcurl4-openssl-dev \
-            libprotobuf-dev \
-            protobuf-compiler \
-            libgmock-dev \
-            libgtest-dev \
-            libbenchmark-dev
+          xargs -a apt-packages.txt sudo apt install -y --no-install-recommends --no-install-suggests
 
       - name: run tests
         run: |

--- a/exporters/fluentd/apt-packages.txt
+++ b/exporters/fluentd/apt-packages.txt
@@ -3,6 +3,3 @@ cmake
 ninja-build
 libssl-dev
 libcurl4-openssl-dev
-libgmock-dev
-libgtest-dev
-libbenchmark-dev

--- a/exporters/fluentd/apt-packages.txt
+++ b/exporters/fluentd/apt-packages.txt
@@ -1,0 +1,8 @@
+build-essential
+cmake
+ninja-build
+libssl-dev
+libcurl4-openssl-dev
+libgmock-dev
+libgtest-dev
+libbenchmark-dev

--- a/exporters/geneva/apt-packages.txt
+++ b/exporters/geneva/apt-packages.txt
@@ -1,0 +1,6 @@
+build-essential
+ca-certificates
+wget
+git
+valgrind
+lcov

--- a/exporters/user_events/apt-packages.txt
+++ b/exporters/user_events/apt-packages.txt
@@ -5,6 +5,3 @@ libssl-dev
 libcurl4-openssl-dev
 libprotobuf-dev
 protobuf-compiler
-libgmock-dev
-libgtest-dev
-libbenchmark-dev

--- a/exporters/user_events/apt-packages.txt
+++ b/exporters/user_events/apt-packages.txt
@@ -1,0 +1,10 @@
+build-essential
+cmake
+ninja-build
+libssl-dev
+libcurl4-openssl-dev
+libprotobuf-dev
+protobuf-compiler
+libgmock-dev
+libgtest-dev
+libbenchmark-dev

--- a/instrumentation/boost_log/apt-packages.txt
+++ b/instrumentation/boost_log/apt-packages.txt
@@ -1,0 +1,11 @@
+build-essential
+cmake
+ninja-build
+libssl-dev
+libcurl4-openssl-dev
+libprotobuf-dev
+protobuf-compiler
+libgmock-dev
+libgtest-dev
+libbenchmark-dev
+libboost-log-dev

--- a/instrumentation/boost_log/apt-packages.txt
+++ b/instrumentation/boost_log/apt-packages.txt
@@ -5,7 +5,4 @@ libssl-dev
 libcurl4-openssl-dev
 libprotobuf-dev
 protobuf-compiler
-libgmock-dev
-libgtest-dev
-libbenchmark-dev
 libboost-log-dev

--- a/instrumentation/glog/apt-packages.txt
+++ b/instrumentation/glog/apt-packages.txt
@@ -5,6 +5,4 @@ libssl-dev
 libcurl4-openssl-dev
 libprotobuf-dev
 protobuf-compiler
-libgmock-dev
-libgtest-dev
 libbenchmark-dev

--- a/instrumentation/glog/apt-packages.txt
+++ b/instrumentation/glog/apt-packages.txt
@@ -1,0 +1,10 @@
+build-essential
+cmake
+ninja-build
+libssl-dev
+libcurl4-openssl-dev
+libprotobuf-dev
+protobuf-compiler
+libgmock-dev
+libgtest-dev
+libbenchmark-dev

--- a/instrumentation/log4cxx/apt-packages.txt
+++ b/instrumentation/log4cxx/apt-packages.txt
@@ -5,7 +5,4 @@ libssl-dev
 libcurl4-openssl-dev
 libprotobuf-dev
 protobuf-compiler
-libgmock-dev
-libgtest-dev
-libbenchmark-dev
 liblog4cxx-dev

--- a/instrumentation/log4cxx/apt-packages.txt
+++ b/instrumentation/log4cxx/apt-packages.txt
@@ -1,0 +1,11 @@
+build-essential
+cmake
+ninja-build
+libssl-dev
+libcurl4-openssl-dev
+libprotobuf-dev
+protobuf-compiler
+libgmock-dev
+libgtest-dev
+libbenchmark-dev
+liblog4cxx-dev

--- a/instrumentation/spdlog/apt-packages.txt
+++ b/instrumentation/spdlog/apt-packages.txt
@@ -5,7 +5,4 @@ libssl-dev
 libcurl4-openssl-dev
 libprotobuf-dev
 protobuf-compiler
-libgmock-dev
-libgtest-dev
-libbenchmark-dev
 libspdlog-dev

--- a/instrumentation/spdlog/apt-packages.txt
+++ b/instrumentation/spdlog/apt-packages.txt
@@ -1,0 +1,11 @@
+build-essential
+cmake
+ninja-build
+libssl-dev
+libcurl4-openssl-dev
+libprotobuf-dev
+protobuf-compiler
+libgmock-dev
+libgtest-dev
+libbenchmark-dev
+libspdlog-dev


### PR DESCRIPTION
This improves maintainability by reducing content which is defined in ci workflows which brings the benefit that they can be installed in any workflow they are applicable for.

There is no change in what is installed and the only functional difference is the packages are being passed via stdin rather as parameters on the cli command.

This also makeş it easier to in the future pin the versions.