### PR TITLE
Move google test to a fetch content

### DIFF
--- a/.github/workflows/boost_log.yml
+++ b/.github/workflows/boost_log.yml
@@ -21,13 +21,6 @@ jobs:
     name: CMake Linux
     runs-on: ubuntu-24.04
     steps:
-      - name: checkout googletest
-        uses: actions/checkout@v7.0.1
-        with:
-          repository: "google/googletest"
-          ref: "release-1.12.1"
-          path: "googletest"
-          submodules: "recursive"
       - name: checkout opentelemetry-cpp-contrib
         uses: actions/checkout@v7.0.1
         with:
@@ -55,16 +48,6 @@ jobs:
             libgtest-dev \
             libbenchmark-dev \
             libboost-log-dev
-
-      # This is needed because libgmock-dev libgtest-dev installs 1.11,
-      # and 1.11 breaks the build.
-      - name: build googletest 1.12
-        run: |
-          mkdir -p "${GITHUB_WORKSPACE}/googletest/build"
-          cd "${GITHUB_WORKSPACE}/googletest/build"
-          cmake .. -G Ninja
-          cmake --build . -j$(nproc)
-          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 
       - name: build opentelemetry-cpp
         run: |

--- a/.github/workflows/glog.yml
+++ b/.github/workflows/glog.yml
@@ -21,12 +21,6 @@ jobs:
     name: CMake Linux
     runs-on: ubuntu-24.04
     steps:
-      - name: checkout googletest
-        uses: actions/checkout@v7.0.1
-        with:
-          repository: "google/googletest"
-          ref: "release-1.12.1"
-          path: "googletest"
       - name: checkout glog
         uses: actions/checkout@v7.0.1
         with:
@@ -58,16 +52,6 @@ jobs:
             libgmock-dev \
             libgtest-dev \
             libbenchmark-dev
-
-      # This is needed because libgmock-dev libgtest-dev installs 1.11,
-      # and 1.11 breaks the build.
-      - name: build googletest 1.12
-        run: |
-          mkdir -p "${GITHUB_WORKSPACE}/googletest/build"
-          cd "${GITHUB_WORKSPACE}/googletest/build"
-          cmake .. -G Ninja
-          cmake --build . -j$(nproc)
-          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 
       - name: build glog
         run: |

--- a/.github/workflows/log4cxx.yml
+++ b/.github/workflows/log4cxx.yml
@@ -21,12 +21,6 @@ jobs:
     name: CMake Linux
     runs-on: ubuntu-24.04
     steps:
-      - name: checkout googletest
-        uses: actions/checkout@v7.0.1
-        with:
-          repository: "google/googletest"
-          ref: "release-1.12.1"
-          path: "googletest"
       - name: checkout logging-log4cxx
         uses: actions/checkout@v7.0.1
         with:
@@ -59,16 +53,6 @@ jobs:
             libgtest-dev \
             libbenchmark-dev \
             liblog4cxx-dev
-
-      # This is needed because libgmock-dev libgtest-dev installs 1.11,
-      # and v1.12 is required
-      - name: build googletest 1.12
-        run: |
-          mkdir -p "${GITHUB_WORKSPACE}/googletest/build"
-          cd "${GITHUB_WORKSPACE}/googletest/build"
-          cmake .. -G Ninja
-          cmake --build . -j$(nproc)
-          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 
       # This is needed because liblog4cxx-dev installs 0.12.1-4,
       # and v1.0.0 is required

--- a/.github/workflows/spdlog.yml
+++ b/.github/workflows/spdlog.yml
@@ -21,12 +21,6 @@ jobs:
     name: CMake Linux
     runs-on: ubuntu-24.04
     steps:
-      - name: checkout googletest
-        uses: actions/checkout@v7.0.1
-        with:
-          repository: "google/googletest"
-          ref: "release-1.12.1"
-          path: "googletest"
       - name: checkout opentelemetry-cpp-contrib
         uses: actions/checkout@v7.0.1
         with:
@@ -53,16 +47,6 @@ jobs:
             libgtest-dev \
             libbenchmark-dev \
             libspdlog-dev
-
-      # This is needed because libgmock-dev libgtest-dev installs 1.11,
-      # and 1.11 breaks the build.
-      - name: build googletest 1.12
-        run: |
-          mkdir -p "${GITHUB_WORKSPACE}/googletest/build"
-          cd "${GITHUB_WORKSPACE}/googletest/build"
-          cmake .. -G Ninja
-          cmake --build . -j$(nproc)
-          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 
       - name: build opentelemetry-cpp
         run: |

--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -164,12 +164,12 @@ endif()
 if(BUILD_TESTING)
   if(MAIN_PROJECT)
     FetchContent_Declare(
-      GTest
+      googletest
       GIT_REPOSITORY https://github.com/google/googletest.git
       GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04 # v1.12.0
     )
 
-    FetchContent_MakeAvailable(GTest)
+    FetchContent_MakeAvailable(googletest)
   else()
     if (NOT DEFINED GTEST_BOTH_LIBRARIES)
       message(STATUS_FATAL, "Test is not enable.")

--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -23,6 +23,8 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(MAIN_PROJECT ON)
 endif()
 
+include(FetchContent)
+
 if (MAIN_PROJECT)
   find_package(opentelemetry-cpp CONFIG QUIET)
   if(opentelemetry-cpp_FOUND)
@@ -161,7 +163,13 @@ endif()
 
 if(BUILD_TESTING)
   if(MAIN_PROJECT)
-    find_package(GTest CONFIG REQUIRED)
+    FetchContent_Declare(
+      GTest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04 # v1.12.0
+    )
+
+    FetchContent_MakeAvailable(GTest)
   else()
     if (NOT DEFINED GTEST_BOTH_LIBRARIES)
       message(STATUS_FATAL, "Test is not enable.")

--- a/exporters/user_events/CMakeLists.txt
+++ b/exporters/user_events/CMakeLists.txt
@@ -103,12 +103,12 @@ endif()
 
 if(BUILD_TESTING)
   FetchContent_Declare(
-    GTest
+    googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04 # v1.12.0
   )
 
-  FetchContent_MakeAvailable(GTest)
+  FetchContent_MakeAvailable(googletest)
 
   include_directories(SYSTEM test/decoder)
   enable_testing()

--- a/exporters/user_events/CMakeLists.txt
+++ b/exporters/user_events/CMakeLists.txt
@@ -16,6 +16,8 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   message(STATUS "${PROJECT_NAME} is main project")
 endif()
 
+include(FetchContent)
+
 if(MAIN_PROJECT)
   # TODO: cleanup the dependent packages
   find_package(Protobuf REQUIRED)
@@ -100,20 +102,14 @@ if(WITH_EXAMPLES)
 endif()
 
 if(BUILD_TESTING)
-  if(EXISTS ${CMAKE_BINARY_DIR}/lib/libgtest.a)
-    # Prefer GTest from build tree. GTest is not always working with
-    # CMAKE_PREFIX_PATH
-    set(GTEST_INCLUDE_DIRS
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest/googletest/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest/googlemock/include)
-    set(GTEST_BOTH_LIBRARIES
-        ${CMAKE_BINARY_DIR}/lib/libgtest.a
-        ${CMAKE_BINARY_DIR}/lib/libgtest_main.a
-        ${CMAKE_BINARY_DIR}/lib/libgmock.a)
-  else()
-    find_package(GTest REQUIRED)
-  endif()
-  include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
+  FetchContent_Declare(
+    GTest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04 # v1.12.0
+  )
+
+  FetchContent_MakeAvailable(GTest)
+
   include_directories(SYSTEM test/decoder)
   enable_testing()
   include(GoogleTest)

--- a/exporters/user_events/Docker/Dockerfile
+++ b/exporters/user_events/Docker/Dockerfile
@@ -15,11 +15,6 @@ RUN apt update && apt install -y \
     libcurl4-openssl-dev \
     libgtest-dev
 
-RUN cd /work && git clone --recursive --depth=1 https://github.com/google/googletest.git && \
-    cd googletest && mkdir build && cd build && \
-    cmake -G Ninja -D CMAKE_BUILD_TYPE=Debug .. && \
-    ninja && ninja install
-
 RUN cd /work && \
     git clone --recursive --depth=1 https://github.com/google/benchmark.git && \
     cd benchmark && mkdir out && cd out && \

--- a/instrumentation/boost_log/CMakeLists.txt
+++ b/instrumentation/boost_log/CMakeLists.txt
@@ -69,7 +69,15 @@ if(OPENTELEMETRY_INSTALL)
 endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
-  find_package(GTest 1.12 REQUIRED)
+  include(FetchContent)
+
+  FetchContent_Declare(
+    GTest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04 # v1.12.0
+  )
+
+  FetchContent_MakeAvailable(GTest)
 
   enable_testing()
 

--- a/instrumentation/boost_log/CMakeLists.txt
+++ b/instrumentation/boost_log/CMakeLists.txt
@@ -72,12 +72,12 @@ endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
   FetchContent_Declare(
-    GTest
+    googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04 # v1.12.0
   )
 
-  FetchContent_MakeAvailable(GTest)
+  FetchContent_MakeAvailable(googletest)
 
   enable_testing()
 

--- a/instrumentation/boost_log/CMakeLists.txt
+++ b/instrumentation/boost_log/CMakeLists.txt
@@ -7,6 +7,8 @@ set(this_target opentelemetry_boost_log_sink)
 
 project(${this_target})
 
+include(FetchContent)
+
 find_package(opentelemetry-cpp REQUIRED)
 find_package(Boost 1.73 COMPONENTS log REQUIRED)
 
@@ -69,8 +71,6 @@ if(OPENTELEMETRY_INSTALL)
 endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
-  include(FetchContent)
-
   FetchContent_Declare(
     GTest
     GIT_REPOSITORY https://github.com/google/googletest.git

--- a/instrumentation/glog/CMakeLists.txt
+++ b/instrumentation/glog/CMakeLists.txt
@@ -69,7 +69,15 @@ if(OPENTELEMETRY_INSTALL)
 endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
-  find_package(GTest 1.12 REQUIRED)
+  include(FetchContent)
+
+  FetchContent_Declare(
+    GTest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04 # v1.12.0
+  )
+
+  FetchContent_MakeAvailable(GTest)
 
   enable_testing()
 

--- a/instrumentation/glog/CMakeLists.txt
+++ b/instrumentation/glog/CMakeLists.txt
@@ -7,6 +7,8 @@ set(this_target opentelemetry_glog_sink)
 
 project(${this_target})
 
+include(FetchContent)
+
 find_package(opentelemetry-cpp REQUIRED)
 find_package(glog 0.7.0 REQUIRED)
 

--- a/instrumentation/glog/CMakeLists.txt
+++ b/instrumentation/glog/CMakeLists.txt
@@ -74,12 +74,12 @@ if(BUILD_TESTING)
   include(FetchContent)
 
   FetchContent_Declare(
-    GTest
+    googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04 # v1.12.0
   )
 
-  FetchContent_MakeAvailable(GTest)
+  FetchContent_MakeAvailable(googletest)
 
   enable_testing()
 

--- a/instrumentation/log4cxx/CMakeLists.txt
+++ b/instrumentation/log4cxx/CMakeLists.txt
@@ -7,6 +7,8 @@ set(this_target opentelemetry_log4cxx_appender)
 
 project(${this_target})
 
+include(FetchContent)
+
 find_package(opentelemetry-cpp QUIET)
 
 if (opentelemetry-cpp_FOUND)
@@ -84,8 +86,6 @@ if(OPENTELEMETRY_INSTALL)
 endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
-  include(FetchContent)
-
   FetchContent_Declare(
     GTest
     GIT_REPOSITORY https://github.com/google/googletest.git

--- a/instrumentation/log4cxx/CMakeLists.txt
+++ b/instrumentation/log4cxx/CMakeLists.txt
@@ -87,12 +87,12 @@ endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
   FetchContent_Declare(
-    GTest
+    googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04 # v1.12.0
   )
 
-  FetchContent_MakeAvailable(GTest)
+  FetchContent_MakeAvailable(googletest)
 
   enable_testing()
 

--- a/instrumentation/log4cxx/CMakeLists.txt
+++ b/instrumentation/log4cxx/CMakeLists.txt
@@ -84,7 +84,15 @@ if(OPENTELEMETRY_INSTALL)
 endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
-  find_package(GTest 1.12 REQUIRED)
+  include(FetchContent)
+
+  FetchContent_Declare(
+    GTest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04 # v1.12.0
+  )
+
+  FetchContent_MakeAvailable(GTest)
 
   enable_testing()
 

--- a/instrumentation/spdlog/CMakeLists.txt
+++ b/instrumentation/spdlog/CMakeLists.txt
@@ -7,6 +7,8 @@ set(this_target opentelemetry_spdlog_sink)
 
 project(${this_target})
 
+include(FetchContent)
+
 find_package(opentelemetry-cpp REQUIRED)
 find_package(spdlog REQUIRED)
 
@@ -69,8 +71,6 @@ if(OPENTELEMETRY_INSTALL)
 endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
-  include(FetchContent)
-
   FetchContent_Declare(
     GTest
     GIT_REPOSITORY https://github.com/google/googletest.git

--- a/instrumentation/spdlog/CMakeLists.txt
+++ b/instrumentation/spdlog/CMakeLists.txt
@@ -69,7 +69,15 @@ if(OPENTELEMETRY_INSTALL)
 endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
-  find_package(GTest 1.12 REQUIRED)
+  include(FetchContent)
+
+  FetchContent_Declare(
+    GTest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04 # v1.18.0
+  )
+
+  FetchContent_MakeAvailable(GTest)
 
   enable_testing()
 

--- a/instrumentation/spdlog/CMakeLists.txt
+++ b/instrumentation/spdlog/CMakeLists.txt
@@ -72,12 +72,12 @@ endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
   FetchContent_Declare(
-    GTest
+    googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04 # v1.18.0
   )
 
-  FetchContent_MakeAvailable(GTest)
+  FetchContent_MakeAvailable(googletest)
 
   enable_testing()
 


### PR DESCRIPTION
This moves google test into cmake for the package rather than a dedicated checkout, this means all cmake benefit rather than just ci and increases testability.