### PR TITLE
Replace find package in glog, geneva & fleuntd

### DIFF
--- a/.github/workflows/fluentd.yml
+++ b/.github/workflows/fluentd.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '*'
+      - 'main'
     paths:
       - 'exporters/fluentd/**'
       - '.github/workflows/fluentd.yml'

--- a/.github/workflows/geneva_metrics.yml
+++ b/.github/workflows/geneva_metrics.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '*'
+      - 'main'
     paths:
       - 'exporters/geneva/**'
       - '.github/workflows/geneva_metrics.yml'

--- a/.github/workflows/geneva_metrics.yml
+++ b/.github/workflows/geneva_metrics.yml
@@ -36,9 +36,6 @@ jobs:
             ca-certificates wget git valgrind lcov
       - name: run tests
         run: |
-          pushd "$GITHUB_WORKSPACE/otel_cpp"
-          sudo ./ci/install_thirdparty.sh --install-dir /usr/local --tags-file third_party_release --packages "googletest;benchmark"
-          popd
           mkdir -p "$GITHUB_WORKSPACE/otel_cpp/build"
           cd "$GITHUB_WORKSPACE/otel_cpp/build"
           cmake .. -DOPENTELEMETRY_INSTALL=ON

--- a/.github/workflows/geneva_trace.yml
+++ b/.github/workflows/geneva_trace.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '*'
+      - 'main'
     paths:
       - 'exporters/geneva-trace/**'
       - '.github/workflows/geneva_trace.yml'

--- a/.github/workflows/glog.yml
+++ b/.github/workflows/glog.yml
@@ -1,6 +1,7 @@
 name: glog
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - '*'
@@ -21,12 +22,6 @@ jobs:
     name: CMake Linux
     runs-on: ubuntu-24.04
     steps:
-      - name: checkout glog
-        uses: actions/checkout@v7.0.1
-        with:
-          repository: "google/glog"
-          ref: "v0.7.0"
-          path: "glog"
       - name: checkout opentelemetry-cpp-contrib
         uses: actions/checkout@v7.0.1
         with:
@@ -52,14 +47,6 @@ jobs:
             libgmock-dev \
             libgtest-dev \
             libbenchmark-dev
-
-      - name: build glog
-        run: |
-          mkdir -p "${GITHUB_WORKSPACE}/glog/build"
-          cd "${GITHUB_WORKSPACE}/glog/build"
-          cmake .. -G Ninja
-          cmake --build . -j$(nproc)
-          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
 
       - name: build opentelemetry-cpp
         run: |

--- a/exporters/fluentd/CMakeLists.txt
+++ b/exporters/fluentd/CMakeLists.txt
@@ -55,11 +55,6 @@ else()
   endif()
 endif()
 
-if(MAIN_PROJECT)
-  find_package(CURL REQUIRED)
-  find_package(Threads REQUIRED)
-endif()
-
 include_directories(include)
 
 if(OPENTELEMETRY_ENABLE_FLUENT_RESOURCE_PUBLISH_EXPERIMENTAL)

--- a/exporters/geneva/CMakeLists.txt
+++ b/exporters/geneva/CMakeLists.txt
@@ -74,6 +74,8 @@ if(BUILD_TESTING)
 
   FetchContent_MakeAvailable(googletest)
 
+  include_directories(SYSTEM test/decoder)
+
   enable_testing()
 
   set(testname geneva_metrics_exporter_test)
@@ -83,8 +85,13 @@ if(BUILD_TESTING)
   # build geneva metrics tests
   add_compile_definitions(KS_STR_ENCODING_NONE)
   add_executable(${testname}
-    test/metrics_exporter_test.cc test/decoder/ifx_metrics_bin.cpp
+    test/metrics_exporter_test.cc
+    test/decoder/ifx_metrics_bin.cpp
     test/decoder/kaitai/kaitaistream.cpp)
+
+  target_include_directories(${testname} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/test/decoder/kaitai
+  )
 
   target_include_directories(${testname} PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/include
@@ -94,12 +101,12 @@ if(BUILD_TESTING)
   target_link_libraries(${testname} PRIVATE
     GTest::gmock
     GTest::gtest
+    GTest::gtest_main
     opentelemetry_exporter_geneva_metrics)
 
   gtest_add_tests(
     TARGET ${testname}
     TEST_PREFIX exporter.
-    TEST_LIST ${testname}
   )
 endif()
 

--- a/exporters/geneva/CMakeLists.txt
+++ b/exporters/geneva/CMakeLists.txt
@@ -1,9 +1,14 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.12)
 
 # MAIN_PROJECT CHECK determine if fluentd exporter is built as a subproject
 # (using add_subdirectory) or if it is the main project
 #
 set(MAIN_PROJECT OFF)
+
+include(FetchContent)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   project(opentelemetry-geneva-metrics)
@@ -61,37 +66,41 @@ endif()
 set_target_version(opentelemetry_exporter_geneva_metrics)
 
 if(BUILD_TESTING)
-  if(EXISTS ${CMAKE_BINARY_DIR}/lib/libgtest.a)
-    # Prefer GTest from build tree. GTest is not always working with
-    # CMAKE_PREFIX_PATH
-    set(GTEST_INCLUDE_DIRS
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest/googletest/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest/googlemock/include)
-    set(GTEST_BOTH_LIBRARIES
-        ${CMAKE_BINARY_DIR}/lib/libgtest.a
-        ${CMAKE_BINARY_DIR}/lib/libgtest_main.a
-        ${CMAKE_BINARY_DIR}/lib/libgmock.a)
-  else()
-    find_package(GTest REQUIRED)
-  endif()
-  include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
-  include_directories(SYSTEM test/decoder)
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04 # v1.12.0
+  )
+
+  FetchContent_MakeAvailable(googletest)
+
   enable_testing()
+
+  set(testname geneva_metrics_exporter_test)
+
   include(GoogleTest)
+
   # build geneva metrics tests
   add_compile_definitions(KS_STR_ENCODING_NONE)
-  add_executable(
-    geneva_metrics_exporter_test
+  add_executable(${testname}
     test/metrics_exporter_test.cc test/decoder/ifx_metrics_bin.cpp
     test/decoder/kaitai/kaitaistream.cpp)
-  target_link_libraries(
-    geneva_metrics_exporter_test ${GTEST_BOTH_LIBRARIES}
-    ${CMAKE_THREAD_LIBS_INIT} opentelemetry_exporter_geneva_metrics)
+
+  target_include_directories(${testname} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/include
+    ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+  )
+
+  target_link_libraries(${testname} PRIVATE
+    GTest::gmock
+    GTest::gtest
+    opentelemetry_exporter_geneva_metrics)
 
   gtest_add_tests(
-    TARGET geneva_metrics_exporter_test
+    TARGET ${testname}
     TEST_PREFIX exporter.
-    TEST_LIST geneva_metrics_exporter_test)
+    TEST_LIST ${testname}
+  )
 endif()
 
 if(OPENTELEMETRY_INSTALL)
@@ -125,9 +134,19 @@ if(OPENTELEMETRY_INSTALL)
 endif()
 
 if(WITH_EXAMPLES)
-  add_executable(example_metrics example/example_metrics.cc
+  set(example_exe example_metrics)
+  add_executable(${example_exe} example/example_metrics.cc
                                  example/foo_library.cc)
-  target_link_libraries(example_metrics opentelemetry_exporter_geneva_metrics)
+  set_target_properties(${example_exe} PROPERTIES EXPORT_NAME ${example_exe})
+
+  target_include_directories(${example_exe} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/include
+    ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+  )
+
+  target_link_libraries(${example_exe} PRIVATE
+    opentelemetry_exporter_geneva_metrics
+  )
 
   if(NOT WIN32)
     add_executable(stress_test_linux example/stress_test_linux.cc)

--- a/exporters/geneva/CMakeLists.txt
+++ b/exporters/geneva/CMakeLists.txt
@@ -53,11 +53,6 @@ set_target_properties(
   opentelemetry_exporter_geneva_metrics
   PROPERTIES EXPORT_NAME opentelemetry_exporter_geneva_metrics)
 
-if(MAIN_PROJECT)
-   target_include_directories(opentelemetry_exporter_geneva_metrics
-                      PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS})
-endif()
-
 target_link_libraries(opentelemetry_exporter_geneva_metrics
                       PUBLIC opentelemetry-cpp::metrics opentelemetry-cpp::resources opentelemetry-cpp::common)
 

--- a/exporters/geneva/CMakeLists.txt
+++ b/exporters/geneva/CMakeLists.txt
@@ -132,7 +132,6 @@ if(WITH_EXAMPLES)
   set(example_exe example_metrics)
   add_executable(${example_exe} example/example_metrics.cc
                                  example/foo_library.cc)
-  set_target_properties(${example_exe} PROPERTIES EXPORT_NAME ${example_exe})
 
   target_link_libraries(${example_exe} PRIVATE opentelemetry_exporter_geneva_metrics)
 

--- a/exporters/geneva/CMakeLists.txt
+++ b/exporters/geneva/CMakeLists.txt
@@ -56,12 +56,10 @@ set_target_properties(
 if(MAIN_PROJECT)
    target_include_directories(opentelemetry_exporter_geneva_metrics
                       PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS})
-   target_link_libraries(opentelemetry_exporter_geneva_metrics
-                      PUBLIC ${OPENTELEMETRY_CPP_LIBRARIES})
-else()
-   target_link_libraries(opentelemetry_exporter_geneva_metrics
-                      PUBLIC opentelemetry_metrics opentelemetry_resources opentelemetry_common)
 endif()
+
+target_link_libraries(opentelemetry_exporter_geneva_metrics
+                      PUBLIC opentelemetry-cpp::metrics opentelemetry-cpp::resources opentelemetry-cpp::common)
 
 set_target_version(opentelemetry_exporter_geneva_metrics)
 
@@ -97,7 +95,6 @@ if(BUILD_TESTING)
     GTest::gmock
     GTest::gtest
     GTest::gtest_main
-    ${OPENTELEMETRY_CPP_LIBRARIES}
     opentelemetry_exporter_geneva_metrics)
 
   gtest_add_tests(
@@ -142,10 +139,7 @@ if(WITH_EXAMPLES)
                                  example/foo_library.cc)
   set_target_properties(${example_exe} PROPERTIES EXPORT_NAME ${example_exe})
 
-  target_link_libraries(${example_exe} PRIVATE
-    ${OPENTELEMETRY_CPP_LIBRARIES}
-    opentelemetry_exporter_geneva_metrics
-  )
+  target_link_libraries(${example_exe} PRIVATE opentelemetry_exporter_geneva_metrics)
 
   if(NOT WIN32)
     add_executable(stress_test_linux example/stress_test_linux.cc)

--- a/exporters/geneva/CMakeLists.txt
+++ b/exporters/geneva/CMakeLists.txt
@@ -93,15 +93,11 @@ if(BUILD_TESTING)
     ${CMAKE_CURRENT_LIST_DIR}/test/decoder/kaitai
   )
 
-  target_include_directories(${testname} PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/include
-    ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
-  )
-
   target_link_libraries(${testname} PRIVATE
     GTest::gmock
     GTest::gtest
     GTest::gtest_main
+    ${OPENTELEMETRY_CPP_LIBRARIES}
     opentelemetry_exporter_geneva_metrics)
 
   gtest_add_tests(
@@ -146,12 +142,8 @@ if(WITH_EXAMPLES)
                                  example/foo_library.cc)
   set_target_properties(${example_exe} PROPERTIES EXPORT_NAME ${example_exe})
 
-  target_include_directories(${example_exe} PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/include
-    ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
-  )
-
   target_link_libraries(${example_exe} PRIVATE
+    ${OPENTELEMETRY_CPP_LIBRARIES}
     opentelemetry_exporter_geneva_metrics
   )
 

--- a/instrumentation/glog/CMakeLists.txt
+++ b/instrumentation/glog/CMakeLists.txt
@@ -10,7 +10,13 @@ project(${this_target})
 include(FetchContent)
 
 find_package(opentelemetry-cpp REQUIRED)
-find_package(glog 0.7.0 REQUIRED)
+FetchContent_Declare(
+  glog
+  GIT_REPOSITORY https://github.com/google/glog.git
+  GIT_TAG 34b8da6496aec6a98277808701cfa834fae9801f # v0.7.0
+)
+
+FetchContent_MakeAvailable(glog)
 
 add_library(${this_target} src/sink.cc)
 
@@ -71,8 +77,6 @@ if(OPENTELEMETRY_INSTALL)
 endif() # OPENTELEMETRY_INSTALL
 
 if(BUILD_TESTING)
-  include(FetchContent)
-
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git

--- a/instrumentation/glog/CMakeLists.txt
+++ b/instrumentation/glog/CMakeLists.txt
@@ -10,13 +10,17 @@ project(${this_target})
 include(FetchContent)
 
 find_package(opentelemetry-cpp REQUIRED)
-FetchContent_Declare(
-  glog
-  GIT_REPOSITORY https://github.com/google/glog.git
-  GIT_TAG 34b8da6496aec6a98277808701cfa834fae9801f # v0.7.0
-)
+find_package(glog QUIET)
 
-FetchContent_MakeAvailable(glog)
+if(NOT glog_FOUND)
+  FetchContent_Declare(
+    glog
+    GIT_REPOSITORY https://github.com/google/glog.git
+    GIT_TAG 34b8da6496aec6a98277808701cfa834fae9801f # v0.7.0
+  )
+
+  FetchContent_MakeAvailable(glog)
+endif()
 
 add_library(${this_target} src/sink.cc)
 

--- a/instrumentation/glog/CMakeLists.txt
+++ b/instrumentation/glog/CMakeLists.txt
@@ -10,7 +10,7 @@ project(${this_target})
 include(FetchContent)
 
 find_package(opentelemetry-cpp REQUIRED)
-find_package(glog QUIET)
+find_package(glog 0.7.0 QUIET)
 
 if(NOT glog_FOUND)
   FetchContent_Declare(


### PR DESCRIPTION
This now has fleuntd, geneva & glog obtaining dependencies via fetchContent rather than git repo checkout or package install.

Fleuntd now also does a main project testing