### PR TITLE
ci: Source log4cxx via apt package

### DIFF
--- a/.github/workflows/log4cxx.yml
+++ b/.github/workflows/log4cxx.yml
@@ -23,12 +23,6 @@ jobs:
     name: CMake Linux
     runs-on: ubuntu-24.04
     steps:
-      - name: checkout logging-log4cxx
-        uses: actions/checkout@v7.0.1
-        with:
-          repository: "apache/logging-log4cxx"
-          ref: "rel/v1.2.0"
-          path: "logging-log4cxx"
       - name: checkout opentelemetry-cpp-contrib
         uses: actions/checkout@v7.0.1
         with:
@@ -45,16 +39,6 @@ jobs:
         run: |
           sudo apt update -y
           xargs -a apt-packages.txt sudo apt install -y --no-install-recommends --no-install-suggests
-
-      # This is needed because liblog4cxx-dev installs 0.12.1-4,
-      # and v1.0.0 is required
-      - name: build logging-log4cxx
-        run: |
-          mkdir -p "${GITHUB_WORKSPACE}/logging-log4cxx/build"
-          cd "${GITHUB_WORKSPACE}/logging-log4cxx/build"
-          cmake .. -G Ninja
-          cmake --build . -j$(nproc)
-          cmake --install . --prefix="${GITHUB_WORKSPACE}/sandbox"
       - name: build opentelemetry-cpp
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/opentelemetry-cpp/build"


### PR DESCRIPTION
This switches log4cxx to be sourced from apt package rather than source which is possible due to the package having been updated.