### PR TITLE
doc: add build option about nginx version

### DIFF
--- a/instrumentation/nginx/README.md
+++ b/instrumentation/nginx/README.md
@@ -31,6 +31,15 @@ cmake -DNGINX_VERSION=1.27.3 ..
 make
 ```
 
+### Build options
+
+#### `NGINX_VERSION`
+
+Selects the nginx release to compile the module against. 
+
+Pass this explicitly. When it is omitted, the build instead detects a locally installed nginx
+by running `nginx -v`, and aborts if none is on `PATH`
+
 ## Quick usage
 
 Download the .so file from the latest [GitHub Action run](https://github.com/open-telemetry/opentelemetry-cpp-contrib/actions/workflows/nginx.yml) or follow the instructions above to build. Then modify nginx.conf, or see the [example](test/conf/nginx.conf)


### PR DESCRIPTION
some issues like(https://github.com/open-telemetry/opentelemetry-cpp-contrib/issues/330, https://github.com/open-telemetry/opentelemetry-cpp-contrib/issues/293) can be solved using build with NGINX_VERSION option.

Currently there is no documentation of this, so users are bit confused.